### PR TITLE
Evaluate symbolic links when testing to see if source directory is on GOPATH

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,6 +110,8 @@ func getSourceDir(arg string) string {
 		arg = filepath.Join(cwd(), arg)
 	}
 
+	arg, err := filepath.EvalSymlinks(arg)
+
 	stat, err := os.Stat(arg)
 	if err != nil {
 		fail("No such file or directory '%s'", arg)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,6 +4,8 @@ set -e
 
 counterfeiter='/tmp/counterfeiter_test'
 
+ln -fs $(pwd)/fixtures /tmp/symlinked_fixtures
+
 go build -o $counterfeiter
 
 $counterfeiter fixtures Something
@@ -13,7 +15,10 @@ $counterfeiter fixtures HasOtherTypes
 $counterfeiter fixtures ReusesArgTypes
 $counterfeiter fixtures EmbedsInterfaces
 $counterfeiter fixtures/aliased_package InAliasedPackage
+$counterfeiter /tmp/symlinked_fixtures Something
 
 go build ./fixtures/...
 
 go test -race -v .
+
+rm /tmp/symlinked_fixtures


### PR DESCRIPTION
This fixed the issue in #9, but I'm not sure the test is as elegant as it could be. As the logic lives in `main.go` I wasn't sure how better to implement tests.
