### PR TITLE
Use Go 1.5 on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
-  - 1.4
+  - 1.5
+sudo : false # uses new containerized infrastructure
 install:
   - go get -v -t ./...
 script: scripts/test.sh


### PR DESCRIPTION
Seems like it would be nice to test under the latest stable Go version.

Travis CI also has some [nice new infrastructure](http://docs.travis-ci.com/user/migrating-from-legacy/) that starts builds almost instantaneously (within 10 seconds) and run faster (in many cases).