### PR TITLE
adding underscore to the range of valid package names

### DIFF
--- a/arguments/parser.go
+++ b/arguments/parser.go
@@ -187,7 +187,7 @@ func any(slice []string, needle string) bool {
 
 func restrictToValidPackageName(input string) string {
 	return strings.Map(func(r rune) rune {
-		if (r >= 65 && r <= 90) || (r >= 97 && r <= 122) || (r >= 48 && r <= 57) {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
 			return r
 		} else {
 			return -1

--- a/arguments/parser_test.go
+++ b/arguments/parser_test.go
@@ -264,6 +264,16 @@ var _ = Describe("parsing arguments", func() {
 			Expect(parsedArgs.DestinationPackageName).To(Equal("myspecialpackagefakes"))
 		})
 	})
+
+	Context("when the output dir contains underscores in package name", func() {
+		BeforeEach(func() {
+			args = []string{"fake_command_runner", "MySpecialInterface"}
+		})
+
+		It("should ensure underscores are in the package name", func() {
+			Expect(parsedArgs.DestinationPackageName).To(Equal("fake_command_runnerfakes"))
+		})
+	})
 })
 
 func fakeFileInfo(filename string, isDir bool) os.FileInfo {


### PR DESCRIPTION
https://github.com/maxbrunsfeld/counterfeiter/commit/88a92016cda4bacc1da3651e38f1feeb2e38bde2 is breaking our tests as we allow underscores in package names.
