### PR TITLE
Handle duplicate package names properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ fixtures/fixturesfakes/
 fixtures/symlinked_fixturesfakes/
 locator/locatorfakes/
 terminal/terminalfakes/
+fixtures/dup_packages/a/afakes/
+fixtures/dup_packages/a/v1/v1fakes/
+fixtures/dup_packages/b/v1/v1fakes/
+fixtures/dup_packages/dup_packagesfakes/
+fixtures/dup_packages/v1/v1fakes/

--- a/astutil/mutator.go
+++ b/astutil/mutator.go
@@ -1,0 +1,69 @@
+package astutil
+
+import "go/ast"
+
+func InjectAlias(t *ast.FuncType, importedSpecs map[string]*ast.ImportSpec, aliases map[string]string) {
+	ast.Inspect(t, func(node ast.Node) bool {
+		switch node := node.(type) {
+		case *ast.Field:
+			convertAlias(&node.Type, importedSpecs, aliases)
+		case *ast.StarExpr:
+			convertAlias(&node.X, importedSpecs, aliases)
+		case *ast.MapType:
+			convertAlias(&node.Key, importedSpecs, aliases)
+			convertAlias(&node.Value, importedSpecs, aliases)
+		case *ast.ArrayType:
+			convertAlias(&node.Elt, importedSpecs, aliases)
+		case *ast.ChanType:
+			convertAlias(&node.Value, importedSpecs, aliases)
+		case *ast.Ellipsis:
+			convertAlias(&node.Elt, importedSpecs, aliases)
+		}
+		return true
+	})
+}
+
+func convertAlias(node *ast.Expr, importedSpecs map[string]*ast.ImportSpec, aliases map[string]string) {
+	if typeSel, ok := (*node).(*ast.SelectorExpr); ok {
+		prefixIdent := typeSel.X.(*ast.Ident)
+		spec := importedSpecs[prefixIdent.Name]
+		newAlias := aliases[spec.Path.Value]
+		if newAlias == "." {
+			*node = typeSel.Sel
+		} else {
+			prefixIdent.Name = newAlias
+		}
+	}
+}
+
+func AddPackagePrefix(t *ast.FuncType, pkgName string, knownTypes map[string]bool) {
+	ast.Inspect(t, func(node ast.Node) bool {
+		switch node := node.(type) {
+		case *ast.Field:
+			addPackagePrefixToNode(&node.Type, pkgName, knownTypes)
+		case *ast.StarExpr:
+			addPackagePrefixToNode(&node.X, pkgName, knownTypes)
+		case *ast.MapType:
+			addPackagePrefixToNode(&node.Key, pkgName, knownTypes)
+			addPackagePrefixToNode(&node.Value, pkgName, knownTypes)
+		case *ast.ArrayType:
+			addPackagePrefixToNode(&node.Elt, pkgName, knownTypes)
+		case *ast.ChanType:
+			addPackagePrefixToNode(&node.Value, pkgName, knownTypes)
+		case *ast.Ellipsis:
+			addPackagePrefixToNode(&node.Elt, pkgName, knownTypes)
+		}
+		return true
+	})
+}
+
+func addPackagePrefixToNode(node *ast.Expr, pkgName string, typeNames map[string]bool) {
+	if typeIdent, ok := (*node).(*ast.Ident); ok {
+		if _, ok := typeNames[typeIdent.Name]; ok {
+			*node = &ast.SelectorExpr{
+				X:   ast.NewIdent(pkgName),
+				Sel: typeIdent,
+			}
+		}
+	}
+}

--- a/fixtures/dot_imports.go
+++ b/fixtures/dot_imports.go
@@ -1,0 +1,16 @@
+package fixtures
+
+import (
+	. "bytes"
+	"io"
+	"net/http"
+	. "os"
+)
+
+type DotImports interface {
+	DoThings(io.Writer, *File) *http.Client
+}
+
+func noop() {
+	Count(nil, nil)
+}

--- a/fixtures/dup_packages/a/a.go
+++ b/fixtures/dup_packages/a/a.go
@@ -1,0 +1,7 @@
+package a
+
+import "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/a/v1"
+
+type A interface {
+	V1() v1.I
+}

--- a/fixtures/dup_packages/a/v1/a.go
+++ b/fixtures/dup_packages/a/v1/a.go
@@ -1,0 +1,8 @@
+package v1
+
+type S struct {
+}
+
+type I interface {
+	FromA() S
+}

--- a/fixtures/dup_packages/alias.go
+++ b/fixtures/dup_packages/alias.go
@@ -1,0 +1,13 @@
+package dup_packages
+
+import (
+	"github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/a"
+	av1 "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/a/v1"
+	"github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/b/v1"
+)
+
+type AliasV1 interface {
+	a.A
+	av1.I
+	v1.I
+}

--- a/fixtures/dup_packages/b/v1/b.go
+++ b/fixtures/dup_packages/b/v1/b.go
@@ -1,0 +1,8 @@
+package v1
+
+type S struct {
+}
+
+type I interface {
+	FromB() S
+}

--- a/fixtures/dup_packages/dupA.go
+++ b/fixtures/dup_packages/dupA.go
@@ -1,0 +1,7 @@
+package dup_packages
+
+import "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/a/v1"
+
+type DupA interface {
+	A() v1.S
+}

--- a/fixtures/dup_packages/dupAB.go
+++ b/fixtures/dup_packages/dupAB.go
@@ -1,0 +1,6 @@
+package dup_packages
+
+type DupAB interface {
+	DupA
+	DupB
+}

--- a/fixtures/dup_packages/dupB.go
+++ b/fixtures/dup_packages/dupB.go
@@ -1,0 +1,7 @@
+package dup_packages
+
+import "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/b/v1"
+
+type DupB interface {
+	B() v1.S
+}

--- a/fixtures/dup_packages/dup_packagenames.go
+++ b/fixtures/dup_packages/dup_packagenames.go
@@ -1,0 +1,13 @@
+package dup_packages
+
+import (
+	"github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/a/v1"
+	bv1 "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/b/v1"
+)
+
+type AB interface {
+	A() v1.S
+	v1.I
+	B() bv1.S
+	bv1.I
+}

--- a/fixtures/dup_packages/v1/multi_import.go
+++ b/fixtures/dup_packages/v1/multi_import.go
@@ -1,0 +1,15 @@
+package v1
+
+import (
+	"github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/a/v1"
+	bv1 "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/b/v1"
+)
+
+type S struct {
+}
+
+type MultiAB interface {
+	Mine() S
+	v1.I
+	bv1.I
+}

--- a/locator/locate_function.go
+++ b/locator/locate_function.go
@@ -2,23 +2,32 @@ package locator
 
 import (
 	"go/ast"
+
+	"github.com/maxbrunsfeld/counterfeiter/astutil"
+	"github.com/maxbrunsfeld/counterfeiter/model"
 )
 
 func methodsForFunction(
 	funcNode *ast.FuncType,
 	funcName string,
 	pkgName string,
-	typenamesNeedingPackageAlias map[string]bool,
-) ([]*ast.Field, error) {
+	importSpecs map[string]*ast.ImportSpec,
+	knownTypes map[string]bool,
+) ([]model.Method, error) {
 
 	// this  will mutate the actual ast node to generate "correct code"
 	// it ensures func signatures have the correct package name for
 	// types that belong to the package we are generating code from
 	// e.g.: change "Param" to "foo.Param" when Param belongs to pkg "foo"
-	addPackagePrefixToTypesInGeneratedPackage(funcNode, pkgName, typenamesNeedingPackageAlias)
+	astutil.AddPackagePrefix(funcNode, pkgName, knownTypes)
 
-	return []*ast.Field{{
-		Names: []*ast.Ident{{Name: funcName}},
-		Type:  funcNode,
-	}}, nil
+	return []model.Method{
+		{
+			Imports: importSpecs,
+			Field: &ast.Field{
+				Names: []*ast.Ident{{Name: funcName}},
+				Type:  funcNode,
+			},
+		},
+	}, nil
 }

--- a/model/model.go
+++ b/model/model.go
@@ -2,10 +2,14 @@ package model
 
 import "go/ast"
 
+type Method struct {
+	Imports map[string]*ast.ImportSpec
+	Field   *ast.Field
+}
+
 type InterfaceToFake struct {
 	Name                   string
-	Methods                []*ast.Field
-	ImportSpecs            []*ast.ImportSpec
+	Methods                []Method
 	ImportPath             string
 	PackageName            string
 	RepresentedByInterface bool


### PR DESCRIPTION
- track imports based on their alias
- test duplicate package names
- test dot imports are not affected