### PR TITLE
Generate fakes for interfaces you do not own

### DIFF
--- a/arguments/parser_test.go
+++ b/arguments/parser_test.go
@@ -6,8 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/maxbrunsfeld/counterfeiter/locator/locatorfakes"
-	"github.com/maxbrunsfeld/counterfeiter/terminal/terminalfakes"
+	"github.com/challiwill/counterfeiter/terminal/terminalfakes"
 
 	. "github.com/maxbrunsfeld/counterfeiter/arguments"
 	. "github.com/onsi/ginkgo"
@@ -25,17 +24,8 @@ var _ = Describe("parsing arguments", func() {
 	var fileStatReader FileStatReader
 
 	var ui *terminalfakes.FakeUI
-	var interfaceLocator *locatorfakes.FakeInterfaceLocator
 
 	var failWasCalled bool
-
-	fakeUIBuffer := func() string {
-		var output string
-		for i := 0; i < ui.WriteLineCallCount(); i++ {
-			output = output + ui.WriteLineArgsForCall(i)
-		}
-		return output
-	}
 
 	JustBeforeEach(func() {
 		subject = NewArgumentParser(
@@ -44,7 +34,6 @@ var _ = Describe("parsing arguments", func() {
 			symlinkEvaler,
 			fileStatReader,
 			ui,
-			interfaceLocator,
 		)
 		parsedArgs = subject.ParseArguments(args...)
 	})
@@ -57,7 +46,6 @@ var _ = Describe("parsing arguments", func() {
 		}
 
 		ui = new(terminalfakes.FakeUI)
-		interfaceLocator = new(locatorfakes.FakeInterfaceLocator)
 
 		symlinkEvaler = func(input string) (string, error) {
 			return input, nil
@@ -69,49 +57,33 @@ var _ = Describe("parsing arguments", func() {
 
 	Describe("when a single argument is provided", func() {
 		BeforeEach(func() {
-			args = []string{"my/mypackage"}
-
-			interfaceLocator.GetInterfacesFromFilePathReturns([]string{"Foo", "Bar"})
-			ui.ReadLineFromStdinReturns("1")
-			ui.TerminalIsTTYReturns(true)
+			args = []string{"someonesinterfaces.AnInterface"}
 		})
 
-		Context("but the connecting terminal is not a TTY", func() {
-			BeforeEach(func() {
-				ui.TerminalIsTTYReturns(false)
-			})
-
-			It("should invoke the fail handler", func() {
-				Expect(failWasCalled).To(BeTrue())
-			})
+		It("indicates to not print to stdout", func() {
+			Expect(parsedArgs.PrintToStdOut).To(BeFalse())
 		})
 
-		It("prompts the user for which interface they want", func() {
-			Expect(fakeUIBuffer()).To(ContainSubstring("Which interface to counterfeit?"))
+		It("provides a name for the fake implementing the interface", func() {
+			Expect(parsedArgs.FakeImplName).To(Equal("FakeAnInterface"))
 		})
 
-		It("shows the user each interface found in the given filepath", func() {
-			Expect(fakeUIBuffer()).To(ContainSubstring("1. Foo"))
-			Expect(fakeUIBuffer()).To(ContainSubstring("2. Bar"))
+		It("provides a path for the interface source", func() {
+			Expect(parsedArgs.ImportPath).To(Equal("someonesinterfaces"))
 		})
 
-		It("asks its interface locator for valid interfaces", func() {
-			Expect(interfaceLocator.GetInterfacesFromFilePathCallCount()).To(Equal(1))
-			Expect(interfaceLocator.GetInterfacesFromFilePathArgsForCall(0)).To(Equal("/home/test-user/workspace/my/mypackage"))
+		It("treats the last segment as the interface to counterfeit", func() {
+			Expect(parsedArgs.InterfaceName).To(Equal("AnInterface"))
 		})
 
-		It("yields the interface name the user chose", func() {
-			Expect(parsedArgs.InterfaceName).To(Equal("Foo"))
-		})
-
-		Describe("when the user types an invalid option", func() {
-			BeforeEach(func() {
-				ui.ReadLineFromStdinReturns("garbage")
-			})
-
-			It("invokes its fail handler", func() {
-				Expect(failWasCalled).To(BeTrue())
-			})
+		It("snake cases the filename for the output directory", func() {
+			Expect(parsedArgs.OutputPath).To(Equal(
+				filepath.Join(
+					cwd(),
+					"workspacefakes",
+					"fake_an_interface.go",
+				),
+			))
 		})
 	})
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -44,17 +44,18 @@ var _ = Describe("The counterfeiter CLI", func() {
 	})
 
 	Describe("when given a single argument", func() {
-		It("interactively prompts the user for the interface they want to counterfeit", func() {
-			reader, writer := io.Pipe()
+		BeforeEach(func() {
+			_ = generateDestination(pathToCLI)
+		})
 
-			copyIn("multiple_interfaces.go", pathToCLI)
-			session := startCounterfeiterWithStdinPipe(pathToCLI, reader, "multiple_interfaces.go")
-
-			writer.Write([]byte("1\n"))
-			writer.Close()
+		It("writes a fake for the fully qualified interface that is provided in the argument", func() {
+			session := StartCounterfeiterSingleArg(pathToCLI, "net.Conn")
 
 			Eventually(session).Should(gexec.Exit(0))
-			Expect(string(session.Out.Contents())).To(ContainSubstring("Wrote `FakeFirstInterface`"))
+			output := string(session.Out.Contents())
+			// fmt.Println(output)
+
+			Expect(output).To(ContainSubstring("Wrote `FakeConn`"))
 		})
 	})
 
@@ -95,11 +96,15 @@ func tmpPath(destination string) string {
 	return filepath.Join(tmpDir, "src", destination)
 }
 
-func copyIn(fixture string, destination string) {
+func generateDestination(destination string) string {
 	destination = filepath.Join(destination, "fixtures")
 	err := os.MkdirAll(destination, 0777)
 	Expect(err).ToNot(HaveOccurred())
+	return destination
+}
 
+func copyIn(fixture string, destination string) {
+	destination = generateDestination(destination)
 	filepath.Walk(filepath.Join("..", "fixtures", fixture), func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() {
 			return nil
@@ -135,19 +140,14 @@ func startCounterfeiter(workingDir string, fixtureName string, otherArgs ...stri
 	return session
 }
 
-func startCounterfeiterWithStdinPipe(workingDir string, stdin io.Reader, fixtureName string) *gexec.Session {
+func StartCounterfeiterSingleArg(workingDir string, arg string) *gexec.Session {
 	fakeGoPathDir := filepath.Dir(filepath.Dir(workingDir))
 	absPath, _ := filepath.Abs(fakeGoPathDir)
 	absPathWithSymlinks, _ := filepath.EvalSymlinks(absPath)
 
-	fixturePath := filepath.Join("fixtures", fixtureName)
-	cmd := exec.Command(pathToCounterfeiter, fixturePath)
-	cmd.Stdin = stdin
+	cmd := exec.Command(pathToCounterfeiter, arg)
 	cmd.Dir = workingDir
-	cmd.Env = []string{
-		"GOPATH=" + absPathWithSymlinks,
-		"COUNTERFEITER_INTERACTIVE=1",
-	}
+	cmd.Env = []string{"GOPATH=" + absPathWithSymlinks}
 
 	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).ToNot(HaveOccurred())

--- a/locator/locate_interface.go
+++ b/locator/locate_interface.go
@@ -31,7 +31,7 @@ func methodsForInterface(
 				})
 
 		case *ast.Ident:
-			iface, err := getInterfaceFromImportPath(t.Name, importPath)
+			iface, err := GetInterfaceFromImportPath(t.Name, importPath)
 			if err != nil {
 				return nil, err
 			}
@@ -39,7 +39,7 @@ func methodsForInterface(
 		case *ast.SelectorExpr:
 			pkgAlias := t.X.(*ast.Ident).Name
 			pkgImportPath := findImportPath(importSpecs, pkgAlias)
-			iface, err := getInterfaceFromImportPath(t.Sel.Name, pkgImportPath)
+			iface, err := GetInterfaceFromImportPath(t.Sel.Name, pkgImportPath)
 			if err != nil {
 				return nil, err
 			}

--- a/locator/locator.go
+++ b/locator/locator.go
@@ -11,66 +11,9 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/maxbrunsfeld/counterfeiter/model"
 )
-
-type InterfaceLocator interface {
-	GetInterfacesFromFilePath(string) []string
-}
-
-func NewInterfaceLocator() InterfaceLocator {
-	return interfaceLocator{}
-}
-
-type interfaceLocator struct{}
-
-func (locator interfaceLocator) GetInterfacesFromFilePath(path string) []string {
-	dir, err := getDir(path)
-	if err != nil {
-		panic(err)
-	}
-
-	importPath, err := importPathForDirPath(dir)
-	if err != nil {
-		panic(err)
-	}
-
-	dirPath, err := dirPathForImportPath(importPath)
-	if err != nil {
-		panic(err)
-	}
-
-	packages, err := packagesForDirPath(dirPath)
-	if err != nil {
-		panic(err)
-	}
-
-	interfacesInPackage := []string{}
-	for _, pkg := range packages {
-
-		for _, f := range pkg.Files {
-			ast.Inspect(f, func(node ast.Node) bool {
-				if typeSpec, ok := node.(*ast.TypeSpec); ok {
-					if _, ok := typeSpec.Type.(*ast.InterfaceType); ok {
-						firstRune := rune(typeSpec.Name.Name[0])
-
-						if !unicode.IsUpper(firstRune) {
-							return true
-						}
-
-						interfacesInPackage = append(interfacesInPackage, typeSpec.Name.Name)
-					}
-				}
-
-				return true
-			})
-		}
-	}
-
-	return interfacesInPackage
-}
 
 func GetInterfaceFromFilePath(interfaceName, filePath string) (*model.InterfaceToFake, error) {
 	dirPath, err := getDir(filePath)
@@ -83,10 +26,10 @@ func GetInterfaceFromFilePath(interfaceName, filePath string) (*model.InterfaceT
 		return nil, err
 	}
 
-	return getInterfaceFromImportPath(interfaceName, importPath)
+	return GetInterfaceFromImportPath(interfaceName, importPath)
 }
 
-func getInterfaceFromImportPath(interfaceName, importPath string) (*model.InterfaceToFake, error) {
+func GetInterfaceFromImportPath(interfaceName, importPath string) (*model.InterfaceToFake, error) {
 	dirPath, err := dirPathForImportPath(importPath)
 	if err != nil {
 		return nil, err

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eux
 
 cd "$(dirname "$0")/.."
 
@@ -19,4 +19,4 @@ go run main.go -o fixtures/symlinked_fixturesfakes/fake_something.go $symlinked_
 find . -type d -name '*fakes' | xargs go build
 
 # run the tests using the fakes
-go test -race -v ./...
+go test -v ./...


### PR DESCRIPTION
Replace interactive single argument behavior to specify which interface
to fake out with a new behavior that let's the user generate fakes for
arguments they do not own. This works by specifying a fully qualified
interface path (eg "counterfeiter net/http.CloseNotifier"). The fake is
generated in the current fakes directory.

[Issue #46]