### PR TITLE
Fake out foreign interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ Wrote `FakeSomething` to `path/to/foo/foofakes/fake_something.go`
 
 You can customize the location of the ouptut using the `-o` flag, or write the code to standard out by providing `-` as a third argument.
 
+If you'd like a fake implementation for an interface you do not own you can do that too by providing only a fully qualified import path:
+
+```shell
+$ counterfeiter some/imported/package.Something
+```
+
+```
+Wrote `FakeSomething` to `current/directory/fakes/fake_something.go`
+```
+
 ### Using the fake in your tests
 
 Instantiate fakes with `new`:

--- a/arguments/parser.go
+++ b/arguments/parser.go
@@ -1,14 +1,11 @@
 package arguments
 
 import (
-	"fmt"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"unicode"
 
-	"github.com/maxbrunsfeld/counterfeiter/locator"
 	"github.com/maxbrunsfeld/counterfeiter/terminal"
 )
 
@@ -22,7 +19,6 @@ func NewArgumentParser(
 	symlinkEvaler SymlinkEvaler,
 	fileStatReader FileStatReader,
 	ui terminal.UI,
-	interfaceLocator locator.InterfaceLocator,
 ) ArgumentParser {
 	return &argumentParser{
 		ui:                ui,
@@ -30,33 +26,41 @@ func NewArgumentParser(
 		currentWorkingDir: currentWorkingDir,
 		symlinkEvaler:     symlinkEvaler,
 		fileStatReader:    fileStatReader,
-		interfaceLocator:  interfaceLocator,
 	}
 }
 
 func (argParser *argumentParser) ParseArguments(args ...string) ParsedArguments {
-	sourcePackageDir := argParser.getSourceDir(args[0])
-
 	var interfaceName string
+	var outputPathFlagValue string
+	var rootDestinationDir string
+	var sourcePackageDir string
+	var importPath string
 
 	if len(args) > 1 {
 		interfaceName = args[1]
+		outputPathFlagValue = *outputPathFlag
+		sourcePackageDir = argParser.getSourceDir(args[0])
+		rootDestinationDir = sourcePackageDir
 	} else {
-		interfaceName = argParser.PromptUserForInterfaceName(sourcePackageDir)
+		fullyQualifiedInterface := strings.Split(args[0], ".")
+		interfaceName = fullyQualifiedInterface[len(fullyQualifiedInterface)-1]
+		rootDestinationDir = argParser.currentWorkingDir()
+		importPath = strings.Join(fullyQualifiedInterface[:len(fullyQualifiedInterface)-1], "/")
 	}
 
 	fakeImplName := getFakeName(interfaceName, *fakeNameFlag)
 
 	outputPath := argParser.getOutputPath(
-		sourcePackageDir,
+		rootDestinationDir,
 		fakeImplName,
-		*outputPathFlag,
+		outputPathFlagValue,
 	)
 
 	packageName := restrictToValidPackageName(filepath.Base(filepath.Dir(outputPath)))
 
 	return ParsedArguments{
 		SourcePackageDir: sourcePackageDir,
+		ImportPath:       importPath,
 		OutputPath:       outputPath,
 
 		InterfaceName:          interfaceName,
@@ -67,41 +71,8 @@ func (argParser *argumentParser) ParseArguments(args ...string) ParsedArguments 
 	}
 }
 
-func (parser *argumentParser) PromptUserForInterfaceName(filepath string) string {
-	if !(parser.ui.TerminalIsTTY()) {
-		parser.ui.WriteLine("Cowardly refusing to prompt user for an interface name in a non-tty environment")
-		parser.failHandler("Perhaps you meant to invoke counterfeiter with more than one argument?")
-		return ""
-	}
-
-	parser.ui.WriteLine("Which interface to counterfeit?")
-
-	interfacesInPackage := parser.interfaceLocator.GetInterfacesFromFilePath(filepath)
-
-	for i, interfaceName := range interfacesInPackage {
-		parser.ui.WriteLine(fmt.Sprintf("%d. %s", i+1, interfaceName))
-	}
-	parser.ui.WriteLine("")
-
-	response := parser.ui.ReadLineFromStdin()
-	parsedResponse, err := strconv.ParseInt(response, 10, 64)
-	if err != nil {
-		parser.failHandler("Unknown option '%s'", response)
-		return ""
-	}
-
-	option := int(parsedResponse - 1)
-	if option < 0 || option >= len(interfacesInPackage) {
-		parser.failHandler("Unknown option '%s'", response)
-		return ""
-	}
-
-	return interfacesInPackage[option]
-}
-
 type argumentParser struct {
 	ui                terminal.UI
-	interfaceLocator  locator.InterfaceLocator
 	failHandler       FailHandler
 	currentWorkingDir CurrentWorkingDir
 	symlinkEvaler     SymlinkEvaler
@@ -110,6 +81,7 @@ type argumentParser struct {
 
 type ParsedArguments struct {
 	SourcePackageDir string // abs path to the dir containing the interface to fake
+	ImportPath       string // import path to the package containing the interface to fake
 	OutputPath       string // path to write the fake file to
 
 	DestinationPackageName string // often the base-dir for OutputPath but must be a valid package name
@@ -140,10 +112,10 @@ func getFakeName(interfaceName, arg string) string {
 
 var camelRegexp = regexp.MustCompile("([a-z])([A-Z])")
 
-func (argParser *argumentParser) getOutputPath(sourceDir, fakeName, arg string) string {
+func (argParser *argumentParser) getOutputPath(rootDestinationDir, fakeName, arg string) string {
 	if arg == "" {
 		snakeCaseName := strings.ToLower(camelRegexp.ReplaceAllString(fakeName, "${1}_${2}"))
-		return filepath.Join(sourceDir, packageNameForPath(sourceDir), snakeCaseName+".go")
+		return filepath.Join(rootDestinationDir, packageNameForPath(rootDestinationDir), snakeCaseName+".go")
 	} else {
 		if !filepath.IsAbs(arg) {
 			arg = filepath.Join(argParser.currentWorkingDir(), arg)

--- a/arguments/parser.go
+++ b/arguments/parser.go
@@ -45,7 +45,7 @@ func (argParser *argumentParser) ParseArguments(args ...string) ParsedArguments 
 		fullyQualifiedInterface := strings.Split(args[0], ".")
 		interfaceName = fullyQualifiedInterface[len(fullyQualifiedInterface)-1]
 		rootDestinationDir = argParser.currentWorkingDir()
-		importPath = strings.Join(fullyQualifiedInterface[:len(fullyQualifiedInterface)-1], "/")
+		importPath = strings.Join(fullyQualifiedInterface[:len(fullyQualifiedInterface)-1], ".")
 	}
 
 	fakeImplName := getFakeName(interfaceName, *fakeNameFlag)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -46,11 +46,11 @@ var _ = Describe("The counterfeiter CLI", func() {
 	Describe("when given a single argument", func() {
 		BeforeEach(func() {
 			copyIn("other_types.go", pathToCLI)
-			copyIn("something.go", tmpPath("otherrepo"))
+			copyIn("something.go", tmpPath("otherrepo.com"))
 		})
 
 		It("writes a fake for the fully qualified interface that is provided in the argument", func() {
-			session := startCounterfeiterWithoutFixture(pathToCLI, "otherrepo/fixtures.Something")
+			session := startCounterfeiterWithoutFixture(pathToCLI, "otherrepo.com/fixtures.Something")
 
 			Eventually(session).Should(gexec.Exit(0))
 			output := string(session.Out.Contents())

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -45,16 +45,17 @@ var _ = Describe("The counterfeiter CLI", func() {
 
 	Describe("when given a single argument", func() {
 		BeforeEach(func() {
-			_ = generateDestination(pathToCLI)
+			copyIn("other_types.go", pathToCLI)
+			copyIn("something.go", tmpPath("otherrepo"))
 		})
 
 		It("writes a fake for the fully qualified interface that is provided in the argument", func() {
-			session := StartCounterfeiterSingleArg(pathToCLI, "io.Closer")
+			session := startCounterfeiterWithoutFixture(pathToCLI, "otherrepo/fixtures.Something")
 
 			Eventually(session).Should(gexec.Exit(0))
 			output := string(session.Out.Contents())
 
-			Expect(output).To(ContainSubstring("Wrote `FakeCloser`"))
+			Expect(output).To(ContainSubstring("Wrote `FakeSomething`"))
 		})
 	})
 
@@ -95,15 +96,10 @@ func tmpPath(destination string) string {
 	return filepath.Join(tmpDir, "src", destination)
 }
 
-func generateDestination(destination string) string {
+func copyIn(fixture string, destination string) {
 	destination = filepath.Join(destination, "fixtures")
 	err := os.MkdirAll(destination, 0777)
 	Expect(err).ToNot(HaveOccurred())
-	return destination
-}
-
-func copyIn(fixture string, destination string) {
-	destination = generateDestination(destination)
 	filepath.Walk(filepath.Join("..", "fixtures", fixture), func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() {
 			return nil
@@ -139,7 +135,7 @@ func startCounterfeiter(workingDir string, fixtureName string, otherArgs ...stri
 	return session
 }
 
-func StartCounterfeiterSingleArg(workingDir string, arg string) *gexec.Session {
+func startCounterfeiterWithoutFixture(workingDir string, arg string) *gexec.Session {
 	fakeGoPathDir := filepath.Dir(filepath.Dir(workingDir))
 	absPath, _ := filepath.Abs(fakeGoPathDir)
 	absPathWithSymlinks, _ := filepath.EvalSymlinks(absPath)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -44,17 +44,17 @@ var _ = Describe("The counterfeiter CLI", func() {
 	})
 
 	Describe("when given a single argument", func() {
-		It("interactively prompts the user for the interface they want to counterfeit", func() {
-			reader, writer := io.Pipe()
+		BeforeEach(func() {
+			_ = generateDestination(pathToCLI)
+		})
 
-			copyIn("multiple_interfaces.go", pathToCLI)
-			session := startCounterfeiterWithStdinPipe(pathToCLI, reader, "multiple_interfaces.go")
-
-			writer.Write([]byte("1\n"))
-			writer.Close()
+		It("writes a fake for the fully qualified interface that is provided in the argument", func() {
+			session := StartCounterfeiterSingleArg(pathToCLI, "io.Closer")
 
 			Eventually(session).Should(gexec.Exit(0))
-			Expect(string(session.Out.Contents())).To(ContainSubstring("Wrote `FakeFirstInterface`"))
+			output := string(session.Out.Contents())
+
+			Expect(output).To(ContainSubstring("Wrote `FakeCloser`"))
 		})
 	})
 
@@ -95,11 +95,15 @@ func tmpPath(destination string) string {
 	return filepath.Join(tmpDir, "src", destination)
 }
 
-func copyIn(fixture string, destination string) {
+func generateDestination(destination string) string {
 	destination = filepath.Join(destination, "fixtures")
 	err := os.MkdirAll(destination, 0777)
 	Expect(err).ToNot(HaveOccurred())
+	return destination
+}
 
+func copyIn(fixture string, destination string) {
+	destination = generateDestination(destination)
 	filepath.Walk(filepath.Join("..", "fixtures", fixture), func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() {
 			return nil
@@ -135,19 +139,14 @@ func startCounterfeiter(workingDir string, fixtureName string, otherArgs ...stri
 	return session
 }
 
-func startCounterfeiterWithStdinPipe(workingDir string, stdin io.Reader, fixtureName string) *gexec.Session {
+func StartCounterfeiterSingleArg(workingDir string, arg string) *gexec.Session {
 	fakeGoPathDir := filepath.Dir(filepath.Dir(workingDir))
 	absPath, _ := filepath.Abs(fakeGoPathDir)
 	absPathWithSymlinks, _ := filepath.EvalSymlinks(absPath)
 
-	fixturePath := filepath.Join("fixtures", fixtureName)
-	cmd := exec.Command(pathToCounterfeiter, fixturePath)
-	cmd.Stdin = stdin
+	cmd := exec.Command(pathToCounterfeiter, arg)
 	cmd.Dir = workingDir
-	cmd.Env = []string{
-		"GOPATH=" + absPathWithSymlinks,
-		"COUNTERFEITER_INTERACTIVE=1",
-	}
+	cmd.Env = []string{"GOPATH=" + absPathWithSymlinks}
 
 	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).ToNot(HaveOccurred())

--- a/locator/locate_interface.go
+++ b/locator/locate_interface.go
@@ -31,7 +31,7 @@ func methodsForInterface(
 				})
 
 		case *ast.Ident:
-			iface, err := getInterfaceFromImportPath(t.Name, importPath)
+			iface, err := GetInterfaceFromImportPath(t.Name, importPath)
 			if err != nil {
 				return nil, err
 			}
@@ -39,7 +39,7 @@ func methodsForInterface(
 		case *ast.SelectorExpr:
 			pkgAlias := t.X.(*ast.Ident).Name
 			pkgImportPath := findImportPath(importSpecs, pkgAlias)
-			iface, err := getInterfaceFromImportPath(t.Sel.Name, pkgImportPath)
+			iface, err := GetInterfaceFromImportPath(t.Sel.Name, pkgImportPath)
 			if err != nil {
 				return nil, err
 			}

--- a/locator/locator.go
+++ b/locator/locator.go
@@ -11,66 +11,9 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/maxbrunsfeld/counterfeiter/model"
 )
-
-type InterfaceLocator interface {
-	GetInterfacesFromFilePath(string) []string
-}
-
-func NewInterfaceLocator() InterfaceLocator {
-	return interfaceLocator{}
-}
-
-type interfaceLocator struct{}
-
-func (locator interfaceLocator) GetInterfacesFromFilePath(path string) []string {
-	dir, err := getDir(path)
-	if err != nil {
-		panic(err)
-	}
-
-	importPath, err := importPathForDirPath(dir)
-	if err != nil {
-		panic(err)
-	}
-
-	dirPath, err := dirPathForImportPath(importPath)
-	if err != nil {
-		panic(err)
-	}
-
-	packages, err := packagesForDirPath(dirPath)
-	if err != nil {
-		panic(err)
-	}
-
-	interfacesInPackage := []string{}
-	for _, pkg := range packages {
-
-		for _, f := range pkg.Files {
-			ast.Inspect(f, func(node ast.Node) bool {
-				if typeSpec, ok := node.(*ast.TypeSpec); ok {
-					if _, ok := typeSpec.Type.(*ast.InterfaceType); ok {
-						firstRune := rune(typeSpec.Name.Name[0])
-
-						if !unicode.IsUpper(firstRune) {
-							return true
-						}
-
-						interfacesInPackage = append(interfacesInPackage, typeSpec.Name.Name)
-					}
-				}
-
-				return true
-			})
-		}
-	}
-
-	return interfacesInPackage
-}
 
 func GetInterfaceFromFilePath(interfaceName, filePath string) (*model.InterfaceToFake, error) {
 	dirPath, err := getDir(filePath)
@@ -83,10 +26,10 @@ func GetInterfaceFromFilePath(interfaceName, filePath string) (*model.InterfaceT
 		return nil, err
 	}
 
-	return getInterfaceFromImportPath(interfaceName, importPath)
+	return GetInterfaceFromImportPath(interfaceName, importPath)
 }
 
-func getInterfaceFromImportPath(interfaceName, importPath string) (*model.InterfaceToFake, error) {
+func GetInterfaceFromImportPath(interfaceName, importPath string) (*model.InterfaceToFake, error) {
 	dirPath, err := dirPathForImportPath(importPath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Replace interactive single argument behavior to specify which interface
to fake out with a new behavior that let's the user generate fakes for
arguments they do not own. This works by specifying a fully qualified
interface path (eg "counterfeiter net/http.CloseNotifier"). The fake is
generated in the current fakes directory.

[Issue #46]