### PR TITLE
Remove superfluous else block

### DIFF
--- a/fixtures/expected_output/fake_something_factory.example
+++ b/fixtures/expected_output/fake_something_factory.example
@@ -30,9 +30,8 @@ func (fake *FakeSomethingFactory) Spy(arg1 string, arg2 map[string]interface{}) 
 	fake.mutex.Unlock()
 	if fake.Stub != nil {
 		return fake.Stub(arg1, arg2)
-	} else {
-		return fake.returns.result1
 	}
+	return fake.returns.result1
 }
 
 func (fake *FakeSomethingFactory) CallCount() int {

--- a/fixtures/packagegen/packagegenfakes/fake_os.go
+++ b/fixtures/packagegen/packagegenfakes/fake_os.go
@@ -86,9 +86,8 @@ func (fake *FakeOs) FindProcess(pid int) (*os.Process, error) {
 	fake.findProcessMutex.Unlock()
 	if fake.FindProcessStub != nil {
 		return fake.FindProcessStub(pid)
-	} else {
-		return fake.findProcessReturns.result1, fake.findProcessReturns.result2
 	}
+	return fake.findProcessReturns.result1, fake.findProcessReturns.result2
 }
 
 func (fake *FakeOs) FindProcessCallCount() int {
@@ -118,9 +117,8 @@ func (fake *FakeOs) Hostname() (name string, err error) {
 	fake.hostnameMutex.Unlock()
 	if fake.HostnameStub != nil {
 		return fake.HostnameStub()
-	} else {
-		return fake.hostnameReturns.result1, fake.hostnameReturns.result2
 	}
+	return fake.hostnameReturns.result1, fake.hostnameReturns.result2
 }
 
 func (fake *FakeOs) HostnameCallCount() int {
@@ -147,9 +145,8 @@ func (fake *FakeOs) Expand(s string, mapping func(string) string) string {
 	fake.expandMutex.Unlock()
 	if fake.ExpandStub != nil {
 		return fake.ExpandStub(s, mapping)
-	} else {
-		return fake.expandReturns.result1
 	}
+	return fake.expandReturns.result1
 }
 
 func (fake *FakeOs) ExpandCallCount() int {
@@ -194,9 +191,8 @@ func (fake *FakeOs) Environ() []string {
 	fake.environMutex.Unlock()
 	if fake.EnvironStub != nil {
 		return fake.EnvironStub()
-	} else {
-		return fake.environReturns.result1
 	}
+	return fake.environReturns.result1
 }
 
 func (fake *FakeOs) EnvironCallCount() int {
@@ -223,9 +219,8 @@ func (fake *FakeOs) Chtimes(name string, atime time.Time, mtime time.Time) error
 	fake.chtimesMutex.Unlock()
 	if fake.ChtimesStub != nil {
 		return fake.ChtimesStub(name, atime, mtime)
-	} else {
-		return fake.chtimesReturns.result1
 	}
+	return fake.chtimesReturns.result1
 }
 
 func (fake *FakeOs) ChtimesCallCount() int {
@@ -257,9 +252,8 @@ func (fake *FakeOs) MkdirAll(path string, perm os.FileMode) error {
 	fake.mkdirAllMutex.Unlock()
 	if fake.MkdirAllStub != nil {
 		return fake.MkdirAllStub(path, perm)
-	} else {
-		return fake.mkdirAllReturns.result1
 	}
+	return fake.mkdirAllReturns.result1
 }
 
 func (fake *FakeOs) MkdirAllCallCount() int {

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -154,9 +154,8 @@ func (fake *FakeSomething) DoThings(arg1 string, arg2 uint64) (int, error) {
 	fake.doThingsMutex.Unlock()
 	if fake.DoThingsStub != nil {
 		return fake.DoThingsStub(arg1, arg2)
-	} else {
-		return fake.doThingsReturns.result1, fake.doThingsReturns.result2
 	}
+	return fake.doThingsReturns.result1, fake.doThingsReturns.result2
 }
 
 func (fake *FakeSomething) DoThingsCallCount() int {
@@ -311,9 +310,8 @@ func (fake *FakeRequestFactory) Spy(arg1 fixtures.Params, arg2 map[string]interf
 	fake.mutex.Unlock()
 	if fake.Stub != nil {
 		return fake.Stub(arg1, arg2)
-	} else {
-		return fake.returns.result1, fake.returns.result2
 	}
+	return fake.returns.result1, fake.returns.result2
 }
 
 func (fake *FakeRequestFactory) CallCount() int {
@@ -387,9 +385,8 @@ func (fake *FakeSomeInterface) CreateThing() some_packagehyphen_ated.Thing {
 	fake.createThingMutex.Unlock()
 	if fake.CreateThingStub != nil {
 		return fake.CreateThingStub()
-	} else {
-		return fake.createThingReturns.result1
 	}
+	return fake.createThingReturns.result1
 }
 
 func (fake *FakeSomeInterface) CreateThingCallCount() int {
@@ -456,9 +453,8 @@ func (fake *FakeSomethingElse) ReturnStuff() (a, b int) {
 	fake.returnStuffMutex.Unlock()
 	if fake.ReturnStuffStub != nil {
 		return fake.ReturnStuffStub()
-	} else {
-		return fake.returnStuffReturns.result1, fake.returnStuffReturns.result2
 	}
+	return fake.returnStuffReturns.result1, fake.returnStuffReturns.result2
 }
 
 func (fake *FakeSomethingElse) ReturnStuffCallCount() int {


### PR DESCRIPTION
stubbedMethodImplementation generates a superfluous block around possible final return statement. This triggers a warning in some Go linters.