### PR TITLE
Set the returns on a specific call

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ Expect(num).To(Equal(3))
 Expect(err).To(Equal(errors.New("the-error")))
 ```
 
+You can set the return value of one or more specific calls:
+
+```go
+fake.DoThingsReturnsOnCall(1, 3, errors.New("the-error"))
+
+num, err := fake.DoThings("stuff", 5)
+Expect(num).To(Equal(0))
+Expect(err).NotTo(HaveOccurred())
+
+num, err = fake.DoThings("stuff", 5)
+Expect(num).To(Equal(3))
+Expect(err).To(Equal(errors.New("the-error")))
+```
+
 You can also supply them with stub functions:
 
 ```go

--- a/fixtures/expected_output/fake_something_factory.example
+++ b/fixtures/expected_output/fake_something_factory.example
@@ -16,12 +16,16 @@ type FakeSomethingFactory struct {
 	returns struct {
 		result1 string
 	}
+	returnsOnCall map[int]struct {
+		result1 string
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
 func (fake *FakeSomethingFactory) Spy(arg1 string, arg2 map[string]interface{}) string {
 	fake.mutex.Lock()
+	ret, specificReturn := fake.returnsOnCall[len(fake.argsForCall)]
 	fake.argsForCall = append(fake.argsForCall, struct {
 		arg1 string
 		arg2 map[string]interface{}
@@ -30,6 +34,9 @@ func (fake *FakeSomethingFactory) Spy(arg1 string, arg2 map[string]interface{}) 
 	fake.mutex.Unlock()
 	if fake.Stub != nil {
 		return fake.Stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
 	}
 	return fake.returns.result1
 }
@@ -49,6 +56,18 @@ func (fake *FakeSomethingFactory) ArgsForCall(i int) (string, map[string]interfa
 func (fake *FakeSomethingFactory) Returns(result1 string) {
 	fake.Stub = nil
 	fake.returns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeSomethingFactory) ReturnsOnCall(i int, result1 string) {
+	fake.Stub = nil
+	if fake.returnsOnCall == nil {
+		fake.returnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.returnsOnCall[i] = struct {
 		result1 string
 	}{result1}
 }

--- a/fixtures/packagegen/packagegenfakes/fake_os.go
+++ b/fixtures/packagegen/packagegenfakes/fake_os.go
@@ -19,10 +19,18 @@ type FakeOs struct {
 		result1 *os.Process
 		result2 error
 	}
+	findProcessReturnsOnCall map[int]struct {
+		result1 *os.Process
+		result2 error
+	}
 	HostnameStub        func() (name string, err error)
 	hostnameMutex       sync.RWMutex
 	hostnameArgsForCall []struct{}
 	hostnameReturns     struct {
+		result1 string
+		result2 error
+	}
+	hostnameReturnsOnCall map[int]struct {
 		result1 string
 		result2 error
 	}
@@ -35,6 +43,9 @@ type FakeOs struct {
 	expandReturns struct {
 		result1 string
 	}
+	expandReturnsOnCall map[int]struct {
+		result1 string
+	}
 	ClearenvStub        func()
 	clearenvMutex       sync.RWMutex
 	clearenvArgsForCall []struct{}
@@ -42,6 +53,9 @@ type FakeOs struct {
 	environMutex        sync.RWMutex
 	environArgsForCall  []struct{}
 	environReturns      struct {
+		result1 []string
+	}
+	environReturnsOnCall map[int]struct {
 		result1 []string
 	}
 	ChtimesStub        func(name string, atime time.Time, mtime time.Time) error
@@ -54,6 +68,9 @@ type FakeOs struct {
 	chtimesReturns struct {
 		result1 error
 	}
+	chtimesReturnsOnCall map[int]struct {
+		result1 error
+	}
 	MkdirAllStub        func(path string, perm os.FileMode) error
 	mkdirAllMutex       sync.RWMutex
 	mkdirAllArgsForCall []struct {
@@ -61,6 +78,9 @@ type FakeOs struct {
 		perm os.FileMode
 	}
 	mkdirAllReturns struct {
+		result1 error
+	}
+	mkdirAllReturnsOnCall map[int]struct {
 		result1 error
 	}
 	ExitStub        func(code int)
@@ -79,6 +99,7 @@ type FakeOs struct {
 
 func (fake *FakeOs) FindProcess(pid int) (*os.Process, error) {
 	fake.findProcessMutex.Lock()
+	ret, specificReturn := fake.findProcessReturnsOnCall[len(fake.findProcessArgsForCall)]
 	fake.findProcessArgsForCall = append(fake.findProcessArgsForCall, struct {
 		pid int
 	}{pid})
@@ -86,6 +107,9 @@ func (fake *FakeOs) FindProcess(pid int) (*os.Process, error) {
 	fake.findProcessMutex.Unlock()
 	if fake.FindProcessStub != nil {
 		return fake.FindProcessStub(pid)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
 	}
 	return fake.findProcessReturns.result1, fake.findProcessReturns.result2
 }
@@ -110,13 +134,31 @@ func (fake *FakeOs) FindProcessReturns(result1 *os.Process, result2 error) {
 	}{result1, result2}
 }
 
+func (fake *FakeOs) FindProcessReturnsOnCall(i int, result1 *os.Process, result2 error) {
+	fake.FindProcessStub = nil
+	if fake.findProcessReturnsOnCall == nil {
+		fake.findProcessReturnsOnCall = make(map[int]struct {
+			result1 *os.Process
+			result2 error
+		})
+	}
+	fake.findProcessReturnsOnCall[i] = struct {
+		result1 *os.Process
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeOs) Hostname() (name string, err error) {
 	fake.hostnameMutex.Lock()
+	ret, specificReturn := fake.hostnameReturnsOnCall[len(fake.hostnameArgsForCall)]
 	fake.hostnameArgsForCall = append(fake.hostnameArgsForCall, struct{}{})
 	fake.recordInvocation("Hostname", []interface{}{})
 	fake.hostnameMutex.Unlock()
 	if fake.HostnameStub != nil {
 		return fake.HostnameStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
 	}
 	return fake.hostnameReturns.result1, fake.hostnameReturns.result2
 }
@@ -135,8 +177,23 @@ func (fake *FakeOs) HostnameReturns(result1 string, result2 error) {
 	}{result1, result2}
 }
 
+func (fake *FakeOs) HostnameReturnsOnCall(i int, result1 string, result2 error) {
+	fake.HostnameStub = nil
+	if fake.hostnameReturnsOnCall == nil {
+		fake.hostnameReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.hostnameReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeOs) Expand(s string, mapping func(string) string) string {
 	fake.expandMutex.Lock()
+	ret, specificReturn := fake.expandReturnsOnCall[len(fake.expandArgsForCall)]
 	fake.expandArgsForCall = append(fake.expandArgsForCall, struct {
 		s       string
 		mapping func(string) string
@@ -145,6 +202,9 @@ func (fake *FakeOs) Expand(s string, mapping func(string) string) string {
 	fake.expandMutex.Unlock()
 	if fake.ExpandStub != nil {
 		return fake.ExpandStub(s, mapping)
+	}
+	if specificReturn {
+		return ret.result1
 	}
 	return fake.expandReturns.result1
 }
@@ -168,6 +228,18 @@ func (fake *FakeOs) ExpandReturns(result1 string) {
 	}{result1}
 }
 
+func (fake *FakeOs) ExpandReturnsOnCall(i int, result1 string) {
+	fake.ExpandStub = nil
+	if fake.expandReturnsOnCall == nil {
+		fake.expandReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.expandReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
 func (fake *FakeOs) Clearenv() {
 	fake.clearenvMutex.Lock()
 	fake.clearenvArgsForCall = append(fake.clearenvArgsForCall, struct{}{})
@@ -186,11 +258,15 @@ func (fake *FakeOs) ClearenvCallCount() int {
 
 func (fake *FakeOs) Environ() []string {
 	fake.environMutex.Lock()
+	ret, specificReturn := fake.environReturnsOnCall[len(fake.environArgsForCall)]
 	fake.environArgsForCall = append(fake.environArgsForCall, struct{}{})
 	fake.recordInvocation("Environ", []interface{}{})
 	fake.environMutex.Unlock()
 	if fake.EnvironStub != nil {
 		return fake.EnvironStub()
+	}
+	if specificReturn {
+		return ret.result1
 	}
 	return fake.environReturns.result1
 }
@@ -208,8 +284,21 @@ func (fake *FakeOs) EnvironReturns(result1 []string) {
 	}{result1}
 }
 
+func (fake *FakeOs) EnvironReturnsOnCall(i int, result1 []string) {
+	fake.EnvironStub = nil
+	if fake.environReturnsOnCall == nil {
+		fake.environReturnsOnCall = make(map[int]struct {
+			result1 []string
+		})
+	}
+	fake.environReturnsOnCall[i] = struct {
+		result1 []string
+	}{result1}
+}
+
 func (fake *FakeOs) Chtimes(name string, atime time.Time, mtime time.Time) error {
 	fake.chtimesMutex.Lock()
+	ret, specificReturn := fake.chtimesReturnsOnCall[len(fake.chtimesArgsForCall)]
 	fake.chtimesArgsForCall = append(fake.chtimesArgsForCall, struct {
 		name  string
 		atime time.Time
@@ -219,6 +308,9 @@ func (fake *FakeOs) Chtimes(name string, atime time.Time, mtime time.Time) error
 	fake.chtimesMutex.Unlock()
 	if fake.ChtimesStub != nil {
 		return fake.ChtimesStub(name, atime, mtime)
+	}
+	if specificReturn {
+		return ret.result1
 	}
 	return fake.chtimesReturns.result1
 }
@@ -242,8 +334,21 @@ func (fake *FakeOs) ChtimesReturns(result1 error) {
 	}{result1}
 }
 
+func (fake *FakeOs) ChtimesReturnsOnCall(i int, result1 error) {
+	fake.ChtimesStub = nil
+	if fake.chtimesReturnsOnCall == nil {
+		fake.chtimesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.chtimesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeOs) MkdirAll(path string, perm os.FileMode) error {
 	fake.mkdirAllMutex.Lock()
+	ret, specificReturn := fake.mkdirAllReturnsOnCall[len(fake.mkdirAllArgsForCall)]
 	fake.mkdirAllArgsForCall = append(fake.mkdirAllArgsForCall, struct {
 		path string
 		perm os.FileMode
@@ -252,6 +357,9 @@ func (fake *FakeOs) MkdirAll(path string, perm os.FileMode) error {
 	fake.mkdirAllMutex.Unlock()
 	if fake.MkdirAllStub != nil {
 		return fake.MkdirAllStub(path, perm)
+	}
+	if specificReturn {
+		return ret.result1
 	}
 	return fake.mkdirAllReturns.result1
 }
@@ -271,6 +379,18 @@ func (fake *FakeOs) MkdirAllArgsForCall(i int) (string, os.FileMode) {
 func (fake *FakeOs) MkdirAllReturns(result1 error) {
 	fake.MkdirAllStub = nil
 	fake.mkdirAllReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeOs) MkdirAllReturnsOnCall(i int, result1 error) {
+	fake.MkdirAllStub = nil
+	if fake.mkdirAllReturnsOnCall == nil {
+		fake.mkdirAllReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.mkdirAllReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -151,6 +151,10 @@ type FakeSomething struct {
 		result1 int
 		result2 error
 	}
+	doThingsReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
+	}
 	DoNothingStub        func()
 	doNothingMutex       sync.RWMutex
 	doNothingArgsForCall []struct{}
@@ -170,6 +174,7 @@ type FakeSomething struct {
 
 func (fake *FakeSomething) DoThings(arg1 string, arg2 uint64) (int, error) {
 	fake.doThingsMutex.Lock()
+	ret, specificReturn := fake.doThingsReturnsOnCall[len(fake.doThingsArgsForCall)]
 	fake.doThingsArgsForCall = append(fake.doThingsArgsForCall, struct {
 		arg1 string
 		arg2 uint64
@@ -178,6 +183,9 @@ func (fake *FakeSomething) DoThings(arg1 string, arg2 uint64) (int, error) {
 	fake.doThingsMutex.Unlock()
 	if fake.DoThingsStub != nil {
 		return fake.DoThingsStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
 	}
 	return fake.doThingsReturns.result1, fake.doThingsReturns.result2
 }
@@ -197,6 +205,20 @@ func (fake *FakeSomething) DoThingsArgsForCall(i int) (string, uint64) {
 func (fake *FakeSomething) DoThingsReturns(result1 int, result2 error) {
 	fake.DoThingsStub = nil
 	fake.doThingsReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSomething) DoThingsReturnsOnCall(i int, result1 int, result2 error) {
+	fake.DoThingsStub = nil
+	if fake.doThingsReturnsOnCall == nil {
+		fake.doThingsReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.doThingsReturnsOnCall[i] = struct {
 		result1 int
 		result2 error
 	}{result1, result2}
@@ -320,12 +342,17 @@ type FakeRequestFactory struct {
 		result1 fixtures.Request
 		result2 error
 	}
+	returnsOnCall map[int]struct {
+		result1 fixtures.Request
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
 func (fake *FakeRequestFactory) Spy(arg1 fixtures.Params, arg2 map[string]interface{}) (fixtures.Request, error) {
 	fake.mutex.Lock()
+	ret, specificReturn := fake.returnsOnCall[len(fake.argsForCall)]
 	fake.argsForCall = append(fake.argsForCall, struct {
 		arg1 fixtures.Params
 		arg2 map[string]interface{}
@@ -334,6 +361,9 @@ func (fake *FakeRequestFactory) Spy(arg1 fixtures.Params, arg2 map[string]interf
 	fake.mutex.Unlock()
 	if fake.Stub != nil {
 		return fake.Stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
 	}
 	return fake.returns.result1, fake.returns.result2
 }
@@ -353,6 +383,20 @@ func (fake *FakeRequestFactory) ArgsForCall(i int) (fixtures.Params, map[string]
 func (fake *FakeRequestFactory) Returns(result1 fixtures.Request, result2 error) {
 	fake.Stub = nil
 	fake.returns = struct {
+		result1 fixtures.Request
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeRequestFactory) ReturnsOnCall(i int, result1 fixtures.Request, result2 error) {
+	fake.Stub = nil
+	if fake.returnsOnCall == nil {
+		fake.returnsOnCall = make(map[int]struct {
+			result1 fixtures.Request
+			result2 error
+		})
+	}
+	fake.returnsOnCall[i] = struct {
 		result1 fixtures.Request
 		result2 error
 	}{result1, result2}
@@ -398,17 +442,24 @@ type FakeSomeInterface struct {
 	createThingReturns struct {
 		result1 some_packagehyphen_ated.Thing
 	}
+	createThingReturnsOnCall map[int]struct {
+		result1 some_packagehyphen_ated.Thing
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
 func (fake *FakeSomeInterface) CreateThing() some_packagehyphen_ated.Thing {
 	fake.createThingMutex.Lock()
+	ret, specificReturn := fake.createThingReturnsOnCall[len(fake.createThingArgsForCall)]
 	fake.createThingArgsForCall = append(fake.createThingArgsForCall, struct{}{})
 	fake.recordInvocation("CreateThing", []interface{}{})
 	fake.createThingMutex.Unlock()
 	if fake.CreateThingStub != nil {
 		return fake.CreateThingStub()
+	}
+	if specificReturn {
+		return ret.result1
 	}
 	return fake.createThingReturns.result1
 }
@@ -422,6 +473,18 @@ func (fake *FakeSomeInterface) CreateThingCallCount() int {
 func (fake *FakeSomeInterface) CreateThingReturns(result1 some_packagehyphen_ated.Thing) {
 	fake.CreateThingStub = nil
 	fake.createThingReturns = struct {
+		result1 some_packagehyphen_ated.Thing
+	}{result1}
+}
+
+func (fake *FakeSomeInterface) CreateThingReturnsOnCall(i int, result1 some_packagehyphen_ated.Thing) {
+	fake.CreateThingStub = nil
+	if fake.createThingReturnsOnCall == nil {
+		fake.createThingReturnsOnCall = make(map[int]struct {
+			result1 some_packagehyphen_ated.Thing
+		})
+	}
+	fake.createThingReturnsOnCall[i] = struct {
 		result1 some_packagehyphen_ated.Thing
 	}{result1}
 }
@@ -466,17 +529,25 @@ type FakeSomethingElse struct {
 		result1 int
 		result2 int
 	}
+	returnStuffReturnsOnCall map[int]struct {
+		result1 int
+		result2 int
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
 func (fake *FakeSomethingElse) ReturnStuff() (a, b int) {
 	fake.returnStuffMutex.Lock()
+	ret, specificReturn := fake.returnStuffReturnsOnCall[len(fake.returnStuffArgsForCall)]
 	fake.returnStuffArgsForCall = append(fake.returnStuffArgsForCall, struct{}{})
 	fake.recordInvocation("ReturnStuff", []interface{}{})
 	fake.returnStuffMutex.Unlock()
 	if fake.ReturnStuffStub != nil {
 		return fake.ReturnStuffStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
 	}
 	return fake.returnStuffReturns.result1, fake.returnStuffReturns.result2
 }
@@ -490,6 +561,20 @@ func (fake *FakeSomethingElse) ReturnStuffCallCount() int {
 func (fake *FakeSomethingElse) ReturnStuffReturns(result1 int, result2 int) {
 	fake.ReturnStuffStub = nil
 	fake.returnStuffReturns = struct {
+		result1 int
+		result2 int
+	}{result1, result2}
+}
+
+func (fake *FakeSomethingElse) ReturnStuffReturnsOnCall(i int, result1 int, result2 int) {
+	fake.ReturnStuffStub = nil
+	if fake.returnStuffReturnsOnCall == nil {
+		fake.returnStuffReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 int
+		})
+	}
+	fake.returnStuffReturnsOnCall[i] = struct {
 		result1 int
 		result2 int
 	}{result1, result2}


### PR DESCRIPTION
This can be used either on its own or in conjunction with setting default
return values.

The scenario which drove me to write this was injecting errors into a complex piece of code where the same fake/method is called multiple times and I want just one of these to fail. The alternative of writing a stub in every such case was quite unwieldy.