### PR TITLE
Basic support for vendored code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.5
+  - 1.7
 sudo : false # uses new containerized infrastructure
 install:
   - go get -v -t . ./arguments ./locator

--- a/fixtures/vendored/bar/bar.go
+++ b/fixtures/vendored/bar/bar.go
@@ -1,0 +1,11 @@
+package bar
+
+import "apackage"
+
+type BarInterface interface {
+	apackage.VendorInterface
+}
+
+type BarVendoredParameter interface {
+	Get(*apackage.BarType) *apackage.BarType
+}

--- a/fixtures/vendored/bar/vendor/apackage/interface.go
+++ b/fixtures/vendored/bar/vendor/apackage/interface.go
@@ -1,0 +1,7 @@
+package apackage
+
+type BarType struct{}
+
+type VendorInterface interface {
+	BarVendor() BarType
+}

--- a/fixtures/vendored/baz/baz.go
+++ b/fixtures/vendored/baz/baz.go
@@ -1,0 +1,7 @@
+package baz
+
+import "apackage"
+
+type BazInterface interface {
+	apackage.VendorInterface
+}

--- a/fixtures/vendored/foo.go
+++ b/fixtures/vendored/foo.go
@@ -1,0 +1,7 @@
+package bar
+
+import "apackage"
+
+type FooInterface interface {
+	apackage.VendorInterface
+}

--- a/fixtures/vendored/vendor/apackage/interface.go
+++ b/fixtures/vendored/vendor/apackage/interface.go
@@ -1,0 +1,7 @@
+package apackage
+
+type FooType struct{}
+
+type VendorInterface interface {
+	FooVendor() FooType
+}

--- a/locator/locate_interface.go
+++ b/locator/locate_interface.go
@@ -13,6 +13,7 @@ func methodsForInterface(
 	pkgName string,
 	importSpecs map[string]*ast.ImportSpec,
 	knownTypes map[string]bool,
+	vendorPaths []string,
 ) ([]model.Method, error) {
 	result := []model.Method{}
 	for _, field := range iface.Methods.List {
@@ -31,7 +32,7 @@ func methodsForInterface(
 				})
 
 		case *ast.Ident:
-			iface, err := GetInterfaceFromImportPath(t.Name, importPath)
+			iface, err := GetInterfaceFromImportPath(t.Name, importPath, vendorPaths...)
 			if err != nil {
 				return nil, err
 			}
@@ -39,7 +40,7 @@ func methodsForInterface(
 		case *ast.SelectorExpr:
 			pkgAlias := t.X.(*ast.Ident).Name
 			pkgImportPath := findImportPath(importSpecs, pkgAlias)
-			iface, err := GetInterfaceFromImportPath(t.Sel.Name, pkgImportPath)
+			iface, err := GetInterfaceFromImportPath(t.Sel.Name, pkgImportPath, vendorPaths...)
 			if err != nil {
 				return nil, err
 			}

--- a/locator/locator_test.go
+++ b/locator/locator_test.go
@@ -189,6 +189,62 @@ var _ = Describe("Locator", func() {
 			// Expect(model.Methods[0].Names[0].Name).To(Equal("DoThings"))
 		})
 	})
+
+	Describe("finding an interface in vendored code", func() {
+		var model *model.InterfaceToFake
+		var err error
+
+		Context("when the vendor dir is in the same directory", func() {
+			JustBeforeEach(func() {
+				model, err = GetInterfaceFromFilePath("FooInterface", "../fixtures/vendored/foo.go")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("returns a model representing the named function alias", func() {
+				Expect(model.Name).To(Equal("FooInterface"))
+				Expect(model.RepresentedByInterface).To(BeTrue())
+			})
+
+			It("should have a single method", func() {
+				Expect(model.Methods).To(HaveLen(1))
+				Expect(model.Methods[0].Field.Names[0].Name).To(Equal("FooVendor"))
+			})
+		})
+
+		Context("when the vendor dir is in a parent directory", func() {
+			JustBeforeEach(func() {
+				model, err = GetInterfaceFromFilePath("BazInterface", "../fixtures/vendored/baz/baz.go")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("returns a model representing the named function alias", func() {
+				Expect(model.Name).To(Equal("BazInterface"))
+				Expect(model.RepresentedByInterface).To(BeTrue())
+			})
+
+			It("should have a single method", func() {
+				Expect(model.Methods).To(HaveLen(1))
+				Expect(model.Methods[0].Field.Names[0].Name).To(Equal("FooVendor"))
+			})
+		})
+
+		Context("when the vendor code shadows a higher level", func() {
+			JustBeforeEach(func() {
+				model, err = GetInterfaceFromFilePath("BarInterface", "../fixtures/vendored/bar/bar.go")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("returns a model representing the named function alias", func() {
+				Expect(model.Name).To(Equal("BarInterface"))
+				Expect(model.RepresentedByInterface).To(BeTrue())
+			})
+
+			It("should have a single method", func() {
+				Expect(model.Methods).To(HaveLen(1))
+				Expect(model.Methods[0].Field.Names[0].Name).To(Equal("BarVendor"))
+			})
+		})
+	})
 })
 
 func collectImports(specs map[string]*ast.ImportSpec) []string {

--- a/scripts/make_fakes.sh
+++ b/scripts/make_fakes.sh
@@ -13,6 +13,7 @@ go build -o $counterfeiter
 egrep --recursive --include '*.go' 'type [^ ]* interface {' . \
       --exclude 'fake_*.go' --exclude '*_test.go' \
   | sed 's#^./\(.*\)/[^/]*.go:type \([^ ]*\) interface {#\1 \2#' \
+  | grep -v 'vendor/' \
   | while read PACKAGE INTERFACE; do $counterfeiter $PACKAGE $INTERFACE; done
 
 # fix an import oddity in the UI fake


### PR DESCRIPTION
This implements basic support for finding interfaces and types from vendored code and may resolve #50. If the general approach is reasonable, I'm happy to rework as necessary.

Regardless, it works for my typical use cases of composing interfaces that are sourced from vendored code and using types from vendored code on my interfaces.