### PR TITLE
remove reliance on  github.com/golang/crypto for TTY check

### DIFF
--- a/terminal/ui.go
+++ b/terminal/ui.go
@@ -3,8 +3,8 @@ package terminal
 import (
 	"bufio"
 	"os"
-
-	"golang.org/x/crypto/ssh/terminal"
+	"syscall"
+	"unsafe"
 )
 
 type UI interface {
@@ -21,8 +21,15 @@ func NewUI() UI {
 
 type ui struct{}
 
+// borrowed from github.com/golang/crypto
+func isTerminal(fd int) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}
+
 func (ui *ui) TerminalIsTTY() bool {
-	isTTY := terminal.IsTerminal(int(os.Stdin.Fd()))
+	isTTY := isTerminal(int(os.Stdin.Fd()))
 	hasOverride := os.Getenv("COUNTERFEITER_INTERACTIVE") == "1"
 	return isTTY || hasOverride
 }


### PR DESCRIPTION
https://github.com/concourse/tsa relies on github.com/golang/crypto , but at an earlier commit SHA. Bumping counterfieter + crypto caused tests to fail due to breaking changes in crypto, since we vendor dependencies as submodules in https://github.com/concourse/concourse and the bump broke TSA.

Could be a better call to avoid dependency clash by replicating the usage of the stdlib in crypto, rather than relying on a crypto. 

There's also https://github.com/burke/ttyutils/ , but there isn't much activity.