### PR TITLE
Don't go get subpackages of counterfeiter on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: go
 go:
   - 1.7
 sudo : false # uses new containerized infrastructure
-install:
-  - go get -v -t . ./arguments ./locator
+go_import_path: github.com/maxbrunsfeld/counterfeiter
+install: scripts/deps.sh
 script: scripts/test.sh

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+go list -f '{{ join .Imports "\n"}}{{"\n"}}{{ join .TestImports "\n" }}{{"\n"}}{{ join .XTestImports "\n"}}' ./... | grep -v "github.com/maxbrunsfeld/counterfeiter" | xargs go get -v


### PR DESCRIPTION
Set go_import path to github.com/maxbrunsfeld/counterfeiter
to make forks build properly.

This should fix build failures in pull requests like this: https://github.com/maxbrunsfeld/counterfeiter/pull/69#issuecomment-303829068