### PR TITLE
Generate import paths without vendor prefix

### DIFF
--- a/locator/locate_interface.go
+++ b/locator/locate_interface.go
@@ -32,7 +32,7 @@ func methodsForInterface(
 				})
 
 		case *ast.Ident:
-			iface, err := GetInterfaceFromImportPath(t.Name, importPath, vendorPaths...)
+			iface, err := getInterface(t.Name, importPath, vendorPaths...)
 			if err != nil {
 				return nil, err
 			}
@@ -40,7 +40,7 @@ func methodsForInterface(
 		case *ast.SelectorExpr:
 			pkgAlias := t.X.(*ast.Ident).Name
 			pkgImportPath := findImportPath(importSpecs, pkgAlias)
-			iface, err := GetInterfaceFromImportPath(t.Sel.Name, pkgImportPath, vendorPaths...)
+			iface, err := getInterface(t.Sel.Name, pkgImportPath, vendorPaths...)
 			if err != nil {
 				return nil, err
 			}

--- a/locator/locator_test.go
+++ b/locator/locator_test.go
@@ -2,6 +2,7 @@ package locator_test
 
 import (
 	"go/ast"
+	"os"
 	"strconv"
 
 	"github.com/maxbrunsfeld/counterfeiter/model"
@@ -245,6 +246,46 @@ var _ = Describe("Locator", func() {
 			It("should have a single method", func() {
 				Expect(model.Methods).To(HaveLen(1))
 				Expect(model.Methods[0].Field.Names[0].Name).To(Equal("BarVendor"))
+			})
+		})
+	})
+
+	Describe("faking a vendored interface", func() {
+		var model *model.InterfaceToFake
+		var err error
+
+		Context("when the interface is provided by a file path", func() {
+			JustBeforeEach(func() {
+				model, err = GetInterfaceFromFilePath("VendorInterface", "../fixtures/vendored/vendor/apackage/interface.go")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("has the correct import with the vendor prefix", func() {
+				Expect(model.ImportPath).To(Equal("apackage"))
+			})
+		})
+
+		Context("when the interface is provided by an import path", func() {
+			var workingDir string
+
+			JustBeforeEach(func() {
+				workingDir, err = os.Getwd()
+				Expect(err).NotTo(HaveOccurred())
+				err = os.Chdir("../fixtures/vendored")
+				Expect(err).NotTo(HaveOccurred())
+
+				model, err = GetInterfaceFromImportPath("VendorInterface", "apackage")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(model.ImportPath).To(Equal("apackage"))
+			})
+
+			AfterEach(func() {
+				err = os.Chdir(workingDir)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("has the correct import with the vendor prefix", func() {
+				Expect(model.ImportPath).To(Equal("apackage"))
 			})
 		})
 	})


### PR DESCRIPTION
For https://github.com/maxbrunsfeld/counterfeiter/issues/75. This change takes a similar approach to https://github.com/maxbrunsfeld/counterfeiter/pull/76 but fixes the issue when either a file path or an import path to the package is provided.