### PR TITLE
Add -v flag to report version and DockerHub integration with Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:alpine AS builder
+RUN apk add --no-cache git
+WORKDIR /go/src/github.com/maxbrunsfeld/counterfeiter
+COPY . ./
+RUN ./scripts/deps.sh
+ARG VERSION=UNKNOWN
+RUN go install -ldflags "-X main.AppVersion=${VERSION}" .
+
+# Use golang as base image so go generate can be used directly
+FROM golang:alpine
+COPY --from=builder /go/bin/counterfeiter /usr/bin/counterfeiter

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,6 @@
+#!/bin/sh
+# This build hook is invoked by Docker Hub when building images from GitHub
+# repository. Documentation can be found at https://docs.docker.com/docker-cloud/builds/advanced
+# Suggested usage is from: https://github.com/docker/hub-feedback/issues/508
+# Version is branch/tag followed by commit hash. (e.g. master-aade01c, v5-c1f2005)
+docker build --build-arg VERSION="$SOURCE_BRANCH-${SOURCE_COMMIT:0:7}" -t $IMAGE_NAME .

--- a/main.go
+++ b/main.go
@@ -17,12 +17,20 @@ import (
 	"github.com/maxbrunsfeld/counterfeiter/terminal"
 )
 
-func main() {
-	flag.Parse()
-	args := flag.Args()
+// AppVersion is replaced with a real version string during build. For example:
+// go install -ldflags "-X main.AppVersion=$(git rev-parse --short HEAD)" github.com/maxbrunsfeld/counterfeiter
+var AppVersion = "UNKNOWN"
 
+func main() {
+	version := flag.Bool("v", false, "print executable version and exit")
+	flag.Parse()
+	if *version {
+		fail("counterfeiter %s", AppVersion)
+		return
+	}
+	args := flag.Args()
 	if len(args) < 1 {
-		fail("%s", usage)
+		fail(usage, AppVersion, os.Args[0])
 		return
 	}
 
@@ -176,8 +184,9 @@ func fail(s string, args ...interface{}) {
 }
 
 var usage = `
+counterfeiter %s
 USAGE
-	counterfeiter
+	%s
 		[-o <output-path>] [-p] [--fake-name <fake-name>]
 		[<source-path>] <interface> [-]
 


### PR DESCRIPTION
This patch address issue #27 and adds a `-v` command line flag to report build version. The usage text is also updated to include version information.

In addition to this, I have added Dockerfile and required hooks to support [automatic building of docker images](https://docs.docker.com/docker-hub/builds/).

@maxbrunsfeld You would have to set up the Docker Hub integration so official Docker build can be provided. If you do not wish to take up the additional burden, I shall be happy to remove it from this PR and do this in a fork.