### PR TITLE
Lock when resetting stubs via Returns / ReturnsOnCall

### DIFF
--- a/generator/function_template.go
+++ b/generator/function_template.go
@@ -88,6 +88,8 @@ func (fake *{{.Function.FakeName}}) ArgsForCall(i int) {{.Function.Params.AsRetu
 
 {{if .Function.Returns.HasLength -}}
 func (fake *{{.Function.FakeName}}) Returns({{.Function.Returns.AsNamedArgsWithTypes}}) {
+	fake.mutex.Lock()
+	defer fake.mutex.Unlock()
 	fake.Stub = nil
 	fake.returns = struct {
 		{{- range .Function.Returns}}
@@ -97,6 +99,8 @@ func (fake *{{.Function.FakeName}}) Returns({{.Function.Returns.AsNamedArgsWithT
 }
 
 func (fake *{{.Function.FakeName}}) ReturnsOnCall(i int, {{.Function.Returns.AsNamedArgsWithTypes}}) {
+	fake.mutex.Lock()
+	defer fake.mutex.Unlock()
 	fake.Stub = nil
 	if fake.returnsOnCall == nil {
 		fake.returnsOnCall = make(map[int]struct {

--- a/generator/interface_template.go
+++ b/generator/interface_template.go
@@ -97,6 +97,8 @@ func (fake *{{.FakeName}}) {{.Name}}ArgsForCall(i int) {{.Params.AsReturnSignatu
 
 {{if .Returns.HasLength -}}
 func (fake *{{.FakeName}}) {{.Name}}Returns({{.Returns.AsNamedArgsWithTypes}}) {
+	fake.{{UnExport .Name}}Mutex.Lock()
+	defer fake.{{UnExport .Name}}Mutex.Unlock()
 	fake.{{.Name}}Stub = nil
 	fake.{{UnExport .Name}}Returns = struct {
 		{{- range .Returns}}
@@ -106,6 +108,8 @@ func (fake *{{.FakeName}}) {{.Name}}Returns({{.Returns.AsNamedArgsWithTypes}}) {
 }
 
 func (fake *{{.FakeName}}) {{.Name}}ReturnsOnCall(i int, {{.Returns.AsNamedArgsWithTypes}}) {
+	fake.{{UnExport .Name}}Mutex.Lock()
+	defer fake.{{UnExport .Name}}Mutex.Unlock()
 	fake.{{.Name}}Stub = nil
 	if fake.{{UnExport .Name}}ReturnsOnCall == nil {
 		fake.{{UnExport .Name}}ReturnsOnCall = make(map[int]struct {

--- a/integration/testdata/expected_fake_multiab.txt
+++ b/integration/testdata/expected_fake_multiab.txt
@@ -63,6 +63,8 @@ func (fake *FakeMultiAB) MineCallCount() int {
 }
 
 func (fake *FakeMultiAB) MineReturns(result1 foo.S) {
+	fake.mineMutex.Lock()
+	defer fake.mineMutex.Unlock()
 	fake.MineStub = nil
 	fake.mineReturns = struct {
 		result1 foo.S
@@ -70,6 +72,8 @@ func (fake *FakeMultiAB) MineReturns(result1 foo.S) {
 }
 
 func (fake *FakeMultiAB) MineReturnsOnCall(i int, result1 foo.S) {
+	fake.mineMutex.Lock()
+	defer fake.mineMutex.Unlock()
 	fake.MineStub = nil
 	if fake.mineReturnsOnCall == nil {
 		fake.mineReturnsOnCall = make(map[int]struct {
@@ -103,6 +107,8 @@ func (fake *FakeMultiAB) FromACallCount() int {
 }
 
 func (fake *FakeMultiAB) FromAReturns(result1 fooa.S) {
+	fake.fromAMutex.Lock()
+	defer fake.fromAMutex.Unlock()
 	fake.FromAStub = nil
 	fake.fromAReturns = struct {
 		result1 fooa.S
@@ -110,6 +116,8 @@ func (fake *FakeMultiAB) FromAReturns(result1 fooa.S) {
 }
 
 func (fake *FakeMultiAB) FromAReturnsOnCall(i int, result1 fooa.S) {
+	fake.fromAMutex.Lock()
+	defer fake.fromAMutex.Unlock()
 	fake.FromAStub = nil
 	if fake.fromAReturnsOnCall == nil {
 		fake.fromAReturnsOnCall = make(map[int]struct {
@@ -143,6 +151,8 @@ func (fake *FakeMultiAB) FromBCallCount() int {
 }
 
 func (fake *FakeMultiAB) FromBReturns(result1 foob.S) {
+	fake.fromBMutex.Lock()
+	defer fake.fromBMutex.Unlock()
 	fake.FromBStub = nil
 	fake.fromBReturns = struct {
 		result1 foob.S
@@ -150,6 +160,8 @@ func (fake *FakeMultiAB) FromBReturns(result1 foob.S) {
 }
 
 func (fake *FakeMultiAB) FromBReturnsOnCall(i int, result1 foob.S) {
+	fake.fromBMutex.Lock()
+	defer fake.fromBMutex.Unlock()
 	fake.FromBStub = nil
 	if fake.fromBReturnsOnCall == nil {
 		fake.fromBReturnsOnCall = make(map[int]struct {

--- a/integration/testdata/expected_fake_somethingfactory.txt
+++ b/integration/testdata/expected_fake_somethingfactory.txt
@@ -55,6 +55,8 @@ func (fake *FakeSomethingFactory) ArgsForCall(i int) (string, map[string]interfa
 }
 
 func (fake *FakeSomethingFactory) Returns(result1 string) {
+	fake.mutex.Lock()
+	defer fake.mutex.Unlock()
 	fake.Stub = nil
 	fake.returns = struct {
 		result1 string
@@ -62,6 +64,8 @@ func (fake *FakeSomethingFactory) Returns(result1 string) {
 }
 
 func (fake *FakeSomethingFactory) ReturnsOnCall(i int, result1 string) {
+	fake.mutex.Lock()
+	defer fake.mutex.Unlock()
 	fake.Stub = nil
 	if fake.returnsOnCall == nil {
 		fake.returnsOnCall = make(map[int]struct {

--- a/integration/testdata/expected_fake_writecloser.txt
+++ b/integration/testdata/expected_fake_writecloser.txt
@@ -58,6 +58,8 @@ func (fake *FakeWriteCloser) CloseCallCount() int {
 }
 
 func (fake *FakeWriteCloser) CloseReturns(result1 error) {
+	fake.closeMutex.Lock()
+	defer fake.closeMutex.Unlock()
 	fake.CloseStub = nil
 	fake.closeReturns = struct {
 		result1 error
@@ -65,6 +67,8 @@ func (fake *FakeWriteCloser) CloseReturns(result1 error) {
 }
 
 func (fake *FakeWriteCloser) CloseReturnsOnCall(i int, result1 error) {
+	fake.closeMutex.Lock()
+	defer fake.closeMutex.Unlock()
 	fake.CloseStub = nil
 	if fake.closeReturnsOnCall == nil {
 		fake.closeReturnsOnCall = make(map[int]struct {
@@ -113,6 +117,8 @@ func (fake *FakeWriteCloser) WriteArgsForCall(i int) []byte {
 }
 
 func (fake *FakeWriteCloser) WriteReturns(result1 int, result2 error) {
+	fake.writeMutex.Lock()
+	defer fake.writeMutex.Unlock()
 	fake.WriteStub = nil
 	fake.writeReturns = struct {
 		result1 int
@@ -121,6 +127,8 @@ func (fake *FakeWriteCloser) WriteReturns(result1 int, result2 error) {
 }
 
 func (fake *FakeWriteCloser) WriteReturnsOnCall(i int, result1 int, result2 error) {
+	fake.writeMutex.Lock()
+	defer fake.writeMutex.Unlock()
 	fake.WriteStub = nil
 	if fake.writeReturnsOnCall == nil {
 		fake.writeReturnsOnCall = make(map[int]struct {


### PR DESCRIPTION
Does not help you if you mutate the stub directly. We will need to add a stub setter to assist people who are directly setting the Stub.

- Partially addresses #44
- Partially addresses #84