### PR TITLE
Omit package name if interface fake is generated in same package as interface

### DIFF
--- a/generator/interface_template.go
+++ b/generator/interface_template.go
@@ -162,6 +162,10 @@ func (fake *{{.Name}}) recordInvocation(key string, args []interface{}) {
 }
 
 {{if IsExported .TargetName -}}
+{{- if eq .TargetAlias .DestinationPackage }}
+var _ {{.TargetName}} = new({{.Name}})
+{{- else }}
 var _ {{.TargetAlias}}.{{.TargetName}} = new({{.Name}})
+{{- end}}
 {{- end}}
 `


### PR DESCRIPTION
Proposed fix for #103. Planning on a unit test around this case.