### PR TITLE
Remove duplicate value fields

### DIFF
--- a/generator/fake.go
+++ b/generator/fake.go
@@ -42,10 +42,9 @@ type Fake struct {
 
 // Method is a method of the interface.
 type Method struct {
-	FakePackage string
-	Name        string
-	Params      Params
-	Returns     Returns
+	Name    string
+	Params  Params
+	Returns Returns
 }
 
 // NewFake returns a Fake that loads the package and finds the interface or the

--- a/generator/fake.go
+++ b/generator/fake.go
@@ -46,9 +46,7 @@ type Method struct {
 	FakePackage string
 	Name        string
 	Params      Params
-	Args        string
 	Returns     Returns
-	Rets        string
 }
 
 // NewFake returns a Fake that loads the package and finds the interface or the

--- a/generator/fake.go
+++ b/generator/fake.go
@@ -42,7 +42,6 @@ type Fake struct {
 
 // Method is a method of the interface.
 type Method struct {
-	FakeName    string
 	FakePackage string
 	Name        string
 	Params      Params

--- a/generator/function_loader.go
+++ b/generator/function_loader.go
@@ -16,6 +16,6 @@ func (f *Fake) loadMethodForFunction() error {
 	}
 	f.addTypesForMethod(sig)
 	importsMap := f.importsMap()
-	f.Function = methodForSignature(sig, f.TargetAlias, f.TargetName, importsMap)
+	f.Function = methodForSignature(sig, f.TargetName, importsMap)
 	return nil
 }

--- a/generator/function_loader.go
+++ b/generator/function_loader.go
@@ -16,7 +16,6 @@ func (f *Fake) loadMethodForFunction() error {
 	}
 	f.addTypesForMethod(sig)
 	importsMap := f.importsMap()
-	function := methodForSignature(sig, f.Name, f.TargetAlias, f.TargetName, importsMap)
-	f.Function = function
+	f.Function = methodForSignature(sig, f.TargetAlias, f.TargetName, importsMap)
 	return nil
 }

--- a/generator/function_template.go
+++ b/generator/function_template.go
@@ -45,7 +45,7 @@ type {{.Name}} struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *{{.Function.FakeName}}) Spy({{.Function.Params.AsNamedArgsWithTypes}}) {{.Function.Returns.AsReturnSignature}} {
+func (fake *{{.Name}}) Spy({{.Function.Params.AsNamedArgsWithTypes}}) {{.Function.Returns.AsReturnSignature}} {
 	{{- range .Function.Params.Slices}}
 	var {{UnExport .Name}}Copy {{.Type}}
 	if {{UnExport .Name}} != nil {
@@ -73,20 +73,20 @@ func (fake *{{.Function.FakeName}}) Spy({{.Function.Params.AsNamedArgsWithTypes}
 	{{- end}}
 }
 
-func (fake *{{.Function.FakeName}}) CallCount() int {
+func (fake *{{.Name}}) CallCount() int {
 	fake.mutex.RLock()
 	defer fake.mutex.RUnlock()
 	return len(fake.argsForCall)
 }
 
-func (fake *{{.Function.FakeName}}) Calls(stub func({{.Function.Params.AsArgs}}) {{.Function.Returns.AsReturnSignature}}) {
+func (fake *{{.Name}}) Calls(stub func({{.Function.Params.AsArgs}}) {{.Function.Returns.AsReturnSignature}}) {
 	fake.mutex.Lock()
 	defer fake.mutex.Unlock()
 	fake.Stub = stub
 }
 
 {{if .Function.Params.HasLength -}}
-func (fake *{{.Function.FakeName}}) ArgsForCall(i int) {{.Function.Params.AsReturnSignature}} {
+func (fake *{{.Name}}) ArgsForCall(i int) {{.Function.Params.AsReturnSignature}} {
 	fake.mutex.RLock()
 	defer fake.mutex.RUnlock()
 	return {{.Function.Params.WithPrefix "fake.argsForCall[i]."}}
@@ -94,7 +94,7 @@ func (fake *{{.Function.FakeName}}) ArgsForCall(i int) {{.Function.Params.AsRetu
 {{- end}}
 
 {{if .Function.Returns.HasLength -}}
-func (fake *{{.Function.FakeName}}) Returns({{.Function.Returns.AsNamedArgsWithTypes}}) {
+func (fake *{{.Name}}) Returns({{.Function.Returns.AsNamedArgsWithTypes}}) {
 	fake.mutex.Lock()
 	defer fake.mutex.Unlock()
 	fake.Stub = nil
@@ -105,7 +105,7 @@ func (fake *{{.Function.FakeName}}) Returns({{.Function.Returns.AsNamedArgsWithT
 	}{ {{- .Function.Returns.AsNamedArgs -}} }
 }
 
-func (fake *{{.Function.FakeName}}) ReturnsOnCall(i int, {{.Function.Returns.AsNamedArgsWithTypes}}) {
+func (fake *{{.Name}}) ReturnsOnCall(i int, {{.Function.Returns.AsNamedArgsWithTypes}}) {
 	fake.mutex.Lock()
 	defer fake.mutex.Unlock()
 	fake.Stub = nil
@@ -124,7 +124,7 @@ func (fake *{{.Function.FakeName}}) ReturnsOnCall(i int, {{.Function.Returns.AsN
 }
 {{- end}}
 
-func (fake *{{.Function.FakeName}}) Invocations() map[string][][]interface{} {
+func (fake *{{.Name}}) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.mutex.RLock()

--- a/generator/generator_internals_test.go
+++ b/generator/generator_internals_test.go
@@ -89,7 +89,6 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 				Expect(f.Package).NotTo(BeNil())
 				Expect(f.Methods).To(HaveLen(0))
 				Expect(f.Function.Name).To(Equal("HandlerFunc"))
-				Expect(f.Function.FakeName).To(Equal("FakeHandlerFunc"))
 				Expect(f.Function.Params).To(HaveLen(2))
 				Expect(f.Function.Returns).To(BeEmpty())
 			})

--- a/generator/interface_loader.go
+++ b/generator/interface_loader.go
@@ -19,7 +19,7 @@ func (f *Fake) addTypesForMethod(sig *types.Signature) {
 	}
 }
 
-func methodForSignature(sig *types.Signature, fakePackage string, methodName string, importsMap map[string]Import) Method {
+func methodForSignature(sig *types.Signature, methodName string, importsMap map[string]Import) Method {
 	params := []Param{}
 	for i := 0; i < sig.Params().Len(); i++ {
 		param := sig.Params().At(i)
@@ -46,10 +46,9 @@ func methodForSignature(sig *types.Signature, fakePackage string, methodName str
 		returns = append(returns, r)
 	}
 	return Method{
-		FakePackage: fakePackage,
-		Name:        methodName,
-		Returns:     returns,
-		Params:      params,
+		Name:    methodName,
+		Returns: returns,
+		Params:  params,
 	}
 }
 
@@ -102,7 +101,7 @@ func (f *Fake) loadMethods() {
 
 	importsMap := f.importsMap()
 	for i := range methods {
-		method := methodForSignature(methods[i].Signature, f.TargetAlias, methods[i].Func.Name(), importsMap)
+		method := methodForSignature(methods[i].Signature, methods[i].Func.Name(), importsMap)
 		f.Methods = append(f.Methods, method)
 	}
 }

--- a/generator/interface_loader.go
+++ b/generator/interface_loader.go
@@ -19,7 +19,7 @@ func (f *Fake) addTypesForMethod(sig *types.Signature) {
 	}
 }
 
-func methodForSignature(sig *types.Signature, fakeName string, fakePackage string, methodName string, importsMap map[string]Import) Method {
+func methodForSignature(sig *types.Signature, fakePackage string, methodName string, importsMap map[string]Import) Method {
 	params := []Param{}
 	for i := 0; i < sig.Params().Len(); i++ {
 		param := sig.Params().At(i)
@@ -46,7 +46,6 @@ func methodForSignature(sig *types.Signature, fakeName string, fakePackage strin
 		returns = append(returns, r)
 	}
 	return Method{
-		FakeName:    fakeName,
 		FakePackage: fakePackage,
 		Name:        methodName,
 		Returns:     returns,
@@ -103,7 +102,7 @@ func (f *Fake) loadMethods() {
 
 	importsMap := f.importsMap()
 	for i := range methods {
-		method := methodForSignature(methods[i].Signature, f.Name, f.TargetAlias, methods[i].Func.Name(), importsMap)
+		method := methodForSignature(methods[i].Signature, f.TargetAlias, methods[i].Func.Name(), importsMap)
 		f.Methods = append(f.Methods, method)
 	}
 }

--- a/generator/interface_template.go
+++ b/generator/interface_template.go
@@ -48,7 +48,7 @@ type {{.Name}} struct {
 }
 
 {{range .Methods -}}
-func (fake *{{.FakeName}}) {{.Name}}({{.Params.AsNamedArgsWithTypes}}) {{.Returns.AsReturnSignature}} {
+func (fake *{{$.Name}}) {{.Name}}({{.Params.AsNamedArgsWithTypes}}) {{.Returns.AsReturnSignature}} {
 	{{- range .Params.Slices}}
 	var {{UnExport .Name}}Copy {{.Type}}
 	if {{UnExport .Name}} != nil {
@@ -81,20 +81,20 @@ func (fake *{{.FakeName}}) {{.Name}}({{.Params.AsNamedArgsWithTypes}}) {{.Return
 	{{- end}}
 }
 
-func (fake *{{.FakeName}}) {{.Name}}CallCount() int {
+func (fake *{{$.Name}}) {{.Name}}CallCount() int {
 	fake.{{UnExport .Name}}Mutex.RLock()
 	defer fake.{{UnExport .Name}}Mutex.RUnlock()
 	return len(fake.{{UnExport .Name}}ArgsForCall)
 }
 
-func (fake *{{.FakeName}}) {{.Name}}Calls(stub func({{.Params.AsArgs}}) {{.Returns.AsReturnSignature}}) {
+func (fake *{{$.Name}}) {{.Name}}Calls(stub func({{.Params.AsArgs}}) {{.Returns.AsReturnSignature}}) {
 	fake.{{UnExport .Name}}Mutex.Lock()
 	defer fake.{{UnExport .Name}}Mutex.Unlock()
 	fake.{{.Name}}Stub = stub
 }
 
 {{if .Params.HasLength -}}
-func (fake *{{.FakeName}}) {{.Name}}ArgsForCall(i int) {{.Params.AsReturnSignature}} {
+func (fake *{{$.Name}}) {{.Name}}ArgsForCall(i int) {{.Params.AsReturnSignature}} {
 	fake.{{UnExport .Name}}Mutex.RLock()
 	defer fake.{{UnExport .Name}}Mutex.RUnlock()
 	argsForCall := fake.{{UnExport .Name}}ArgsForCall[i]
@@ -103,7 +103,7 @@ func (fake *{{.FakeName}}) {{.Name}}ArgsForCall(i int) {{.Params.AsReturnSignatu
 {{- end}}
 
 {{if .Returns.HasLength -}}
-func (fake *{{.FakeName}}) {{.Name}}Returns({{.Returns.AsNamedArgsWithTypes}}) {
+func (fake *{{$.Name}}) {{.Name}}Returns({{.Returns.AsNamedArgsWithTypes}}) {
 	fake.{{UnExport .Name}}Mutex.Lock()
 	defer fake.{{UnExport .Name}}Mutex.Unlock()
 	fake.{{.Name}}Stub = nil
@@ -114,7 +114,7 @@ func (fake *{{.FakeName}}) {{.Name}}Returns({{.Returns.AsNamedArgsWithTypes}}) {
 	}{ {{- .Returns.AsNamedArgs -}} }
 }
 
-func (fake *{{.FakeName}}) {{.Name}}ReturnsOnCall(i int, {{.Returns.AsNamedArgsWithTypes}}) {
+func (fake *{{$.Name}}) {{.Name}}ReturnsOnCall(i int, {{.Returns.AsNamedArgsWithTypes}}) {
 	fake.{{UnExport .Name}}Mutex.Lock()
 	defer fake.{{UnExport .Name}}Mutex.Unlock()
 	fake.{{.Name}}Stub = nil

--- a/generator/package_template.go
+++ b/generator/package_template.go
@@ -35,7 +35,7 @@ type {{.Name}}Shim struct {}
 
 {{- range .Methods}}
 func (p *{{$.Name}}Shim) {{.Name}}({{.Params.AsNamedArgsWithTypes}}) {{.Returns.AsReturnSignature}} {
-  {{if .Returns.HasLength}}return {{end}}{{.FakePackage}}.{{.Name}}({{.Params.AsNamedArgsForInvocation}})
+  {{if .Returns.HasLength}}return {{end}}{{$.TargetAlias}}.{{.Name}}({{.Params.AsNamedArgsForInvocation}})
 }
 {{end}}
 var _ {{.Name}} = new({{.Name}}Shim)

--- a/generator/package_template.go
+++ b/generator/package_template.go
@@ -34,7 +34,7 @@ type {{.Name}} interface {
 type {{.Name}}Shim struct {}
 
 {{- range .Methods}}
-func (p *{{.FakeName}}Shim) {{.Name}}({{.Params.AsNamedArgsWithTypes}}) {{.Returns.AsReturnSignature}} {
+func (p *{{$.Name}}Shim) {{.Name}}({{.Params.AsNamedArgsWithTypes}}) {{.Returns.AsReturnSignature}} {
   {{if .Returns.HasLength}}return {{end}}{{.FakePackage}}.{{.Name}}({{.Params.AsNamedArgsForInvocation}})
 }
 {{end}}


### PR DESCRIPTION
While reading over the code I noticed a couple fields on the `Method` struct that I found particular hard to understand. After reading over the code I realized these fields held copies of values from `Fake`.  They appear to exist solely to render values into the template, but do not feel like natural properties of a `Method` type.

I noticed that at the bottom of https://golang.org/pkg/text/template/#hdr-Variables it says `$` is always set to the initial value of `.`. Using `$` I was able to remove these copied values and use the original value from the `Fake`. 

Fewer fields, especially fields that contain values which are copies of other values, should make the code easier to understand.