### PR TITLE
Shrink main package

### DIFF
--- a/arguments/files.go
+++ b/arguments/files.go
@@ -2,6 +2,5 @@ package arguments
 
 import "os"
 
-type CurrentWorkingDir func() string
 type SymlinkEvaler func(string) (string, error)
 type FileStatReader func(string) (os.FileInfo, error)

--- a/arguments/parser.go
+++ b/arguments/parser.go
@@ -17,7 +17,7 @@ type ArgumentParser interface {
 
 func NewArgumentParser(
 	failHandler FailHandler,
-	currentWorkingDir CurrentWorkingDir,
+	currentWorkingDir string,
 	symlinkEvaler SymlinkEvaler,
 	fileStatReader FileStatReader,
 ) ArgumentParser {
@@ -55,7 +55,7 @@ func (argParser *argumentParser) parseInterfaceArgs(args ...string) ParsedArgume
 	} else {
 		fullyQualifiedInterface := strings.Split(args[0], ".")
 		interfaceName = fullyQualifiedInterface[len(fullyQualifiedInterface)-1]
-		rootDestinationDir = argParser.currentWorkingDir()
+		rootDestinationDir = argParser.currentWorkingDir
 		packagePath = strings.Join(fullyQualifiedInterface[:len(fullyQualifiedInterface)-1], ".")
 	}
 
@@ -99,7 +99,7 @@ func (argParser *argumentParser) parsePackageArgs(args ...string) ParsedArgument
 		// TODO: sensible checking of dirs and symlinks
 		outputPath = *outputPathFlag
 	} else {
-		outputPath = path.Join(argParser.currentWorkingDir(), packageName)
+		outputPath = path.Join(argParser.currentWorkingDir, packageName)
 	}
 
 	log.Printf("Parsed Arguments:\nPackage Name: %s\nDestination Package Name: %s", packagePath, packageName)
@@ -116,7 +116,7 @@ func (argParser *argumentParser) parsePackageArgs(args ...string) ParsedArgument
 
 type argumentParser struct {
 	failHandler       FailHandler
-	currentWorkingDir CurrentWorkingDir
+	currentWorkingDir string
 	symlinkEvaler     SymlinkEvaler
 	fileStatReader    FileStatReader
 }
@@ -162,7 +162,7 @@ func (argParser *argumentParser) getOutputPath(rootDestinationDir, fakeName, out
 		return filepath.Join(rootDestinationDir, packageNameForPath(rootDestinationDir), snakeCaseName+".go")
 	} else {
 		if !filepath.IsAbs(outputPathFlagValue) {
-			outputPathFlagValue = filepath.Join(argParser.currentWorkingDir(), outputPathFlagValue)
+			outputPathFlagValue = filepath.Join(argParser.currentWorkingDir, outputPathFlagValue)
 		}
 		return outputPathFlagValue
 	}
@@ -175,7 +175,7 @@ func packageNameForPath(pathToPackage string) string {
 
 func (argParser *argumentParser) getSourceDir(path string) string {
 	if !filepath.IsAbs(path) {
-		path = filepath.Join(argParser.currentWorkingDir(), path)
+		path = filepath.Join(argParser.currentWorkingDir, path)
 	}
 
 	evaluatedPath, err := argParser.symlinkEvaler(path)

--- a/arguments/parser_test.go
+++ b/arguments/parser_test.go
@@ -26,7 +26,7 @@ func testParsingArguments(t *testing.T, when spec.G, it spec.S) {
 	var args []string
 
 	var fail FailHandler
-	var cwd CurrentWorkingDir
+	var cwd string
 	var symlinkEvaler SymlinkEvaler
 	var fileStatReader FileStatReader
 
@@ -55,9 +55,7 @@ func testParsingArguments(t *testing.T, when spec.G, it spec.S) {
 			failWasCalledWithArgs = args
 
 		}
-		cwd = func() string {
-			return "/home/test-user/workspace"
-		}
+		cwd = "/home/test-user/workspace"
 
 		symlinkEvaler = func(input string) (string, error) {
 			return input, nil
@@ -82,7 +80,7 @@ func testParsingArguments(t *testing.T, when spec.G, it spec.S) {
 		when("given a stdlib package", func() {
 			it("sets arguments as expected", func() {
 				Expect(parsedArgs.SourcePackageDir).To(Equal("os"))
-				Expect(parsedArgs.OutputPath).To(Equal(path.Join(cwd(), "osshim")))
+				Expect(parsedArgs.OutputPath).To(Equal(path.Join(cwd, "osshim")))
 				Expect(parsedArgs.DestinationPackageName).To(Equal("osshim"))
 			})
 		})
@@ -115,7 +113,7 @@ func testParsingArguments(t *testing.T, when spec.G, it spec.S) {
 		it("snake cases the filename for the output directory", func() {
 			Expect(parsedArgs.OutputPath).To(Equal(
 				filepath.Join(
-					cwd(),
+					cwd,
 					"workspacefakes",
 					"fake_an_interface.go",
 				),
@@ -237,7 +235,7 @@ func testParsingArguments(t *testing.T, when spec.G, it spec.S) {
 					Expect(failWasCalledWithArgs).To(HaveLen(1))
 
 					arg := failWasCalledWithArgs[0]
-					Expect(arg).To(Equal(path.Join(cwd(), "my/my5package")))
+					Expect(arg).To(Equal(path.Join(cwd, "my/my5package")))
 				})
 			})
 
@@ -256,7 +254,7 @@ func testParsingArguments(t *testing.T, when spec.G, it spec.S) {
 					Expect(failWasCalledWithArgs).To(HaveLen(1))
 
 					arg := failWasCalledWithArgs[0]
-					Expect(arg).To(Equal(path.Join(cwd(), "my/my5package")))
+					Expect(arg).To(Equal(path.Join(cwd, "my/my5package")))
 				})
 			})
 		})

--- a/arguments/parser_windows_test.go
+++ b/arguments/parser_windows_test.go
@@ -24,7 +24,7 @@ func testParsingArguments(t *testing.T, when spec.G, it spec.S) {
 	var args []string
 
 	var fail FailHandler
-	var cwd CurrentWorkingDir
+	var cwd string
 	var symlinkEvaler SymlinkEvaler
 	var fileStatReader FileStatReader
 
@@ -54,9 +54,7 @@ func testParsingArguments(t *testing.T, when spec.G, it spec.S) {
 			failWasCalledWithMessage = msg
 			failWasCalledWithArgs = args
 		}
-		cwd = func() string {
-			return "C:\\Users\\test-user\\workspace"
-		}
+		cwd = "C:\\Users\\test-user\\workspace"
 
 		symlinkEvaler = func(input string) (string, error) {
 			return input, nil

--- a/main.go
+++ b/main.go
@@ -111,6 +111,7 @@ func printCode(code, outputPath string, printToStdOut bool) error {
 
 	if printToStdOut {
 		fmt.Println(code)
+		return nil
 	}
 	os.MkdirAll(filepath.Dir(outputPath), 0777)
 	file, err := os.Create(outputPath)

--- a/main.go
+++ b/main.go
@@ -143,22 +143,6 @@ func reportDoneSimple(printToStdOut bool) {
 	fmt.Fprint(writer, "Done\n")
 }
 
-func reportDone(printToStdOut bool, outputPath, fakeName string) {
-	rel, err := filepath.Rel(cwd(), outputPath)
-	if err != nil {
-		fail("%v", err)
-	}
-
-	var writer io.Writer
-	if printToStdOut {
-		writer = os.Stderr
-	} else {
-		writer = os.Stdout
-	}
-
-	fmt.Fprint(writer, fmt.Sprintf("Wrote `%s` to `%s`\n", fakeName, rel))
-}
-
 func cwd() string {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"go/format"
-	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -65,7 +64,7 @@ func isDebug() bool {
 }
 
 func generate(workingDir string, args arguments.ParsedArguments) {
-	reportStarting(args.PrintToStdOut, args.OutputPath, args.FakeImplName)
+	reportStarting(args.OutputPath, args.FakeImplName)
 
 	b, err := doGenerate(workingDir, args)
 	if err != nil {
@@ -73,7 +72,7 @@ func generate(workingDir string, args arguments.ParsedArguments) {
 	}
 
 	printCode(string(b), args.OutputPath, args.PrintToStdOut)
-	reportDoneSimple(args.PrintToStdOut)
+	fmt.Fprint(os.Stderr, "Done\n")
 }
 
 func doGenerate(workingDir string, args arguments.ParsedArguments) ([]byte, error) {
@@ -112,35 +111,17 @@ func printCode(code, outputPath string, printToStdOut bool) {
 	}
 }
 
-func reportStarting(printToStdOut bool, outputPath, fakeName string) {
+func reportStarting(outputPath, fakeName string) {
 	rel, err := filepath.Rel(cwd(), outputPath)
 	if err != nil {
 		fail("%v", err)
-	}
-
-	var writer io.Writer
-	if printToStdOut {
-		writer = os.Stderr
-	} else {
-		writer = os.Stdout
 	}
 
 	msg := fmt.Sprintf("Writing `%s` to `%s`... ", fakeName, rel)
 	if isDebug() {
 		msg = msg + "\n"
 	}
-	fmt.Fprint(writer, msg)
-}
-
-func reportDoneSimple(printToStdOut bool) {
-	var writer io.Writer
-	if printToStdOut {
-		writer = os.Stderr
-	} else {
-		writer = os.Stdout
-	}
-
-	fmt.Fprint(writer, "Done\n")
+	fmt.Fprint(os.Stderr, msg)
 }
 
 func cwd() string {


### PR DESCRIPTION
Full description in the commit message.

One of the stated goals in the readme of this project is to keep `main` small. I noticed some duplicate code and unused function in main that could be cleaned up.