### PR TITLE
Only add import aliases to fake package when necessary

### DIFF
--- a/generator/function_template.go
+++ b/generator/function_template.go
@@ -5,7 +5,7 @@ import (
 	"text/template"
 )
 
-var functionFuncs template.FuncMap = template.FuncMap{
+var functionFuncs = template.FuncMap{
 	"ToLower":    strings.ToLower,
 	"UnExport":   unexport,
 	"Replace":    strings.Replace,
@@ -17,7 +17,7 @@ package {{.DestinationPackage}}
 
 import (
 	{{- range $index, $import := .Imports.ByAlias}}
-	{{$import.Alias}} "{{$import.PkgPath}}"
+	{{$import}}
 	{{- end}}
 )
 

--- a/generator/import.go
+++ b/generator/import.go
@@ -1,7 +1,9 @@
 package generator
 
 import (
+	"fmt"
 	"go/types"
+	"path"
 	"strings"
 
 	"golang.org/x/tools/imports"
@@ -25,6 +27,16 @@ func newImports() Imports {
 type Import struct {
 	Alias   string
 	PkgPath string
+}
+
+// String returns a string that may be used as an import line in a go source
+// file. Imports with aliases that match the package basename are printed without
+// an alias.
+func (i Import) String() string {
+	if path.Base(i.PkgPath) == i.Alias {
+		return `"` + i.PkgPath + `"`
+	}
+	return fmt.Sprintf(`%s "%s"`, i.Alias, i.PkgPath)
 }
 
 // AddImport creates an import with the given alias and path, and adds it to

--- a/generator/import_test.go
+++ b/generator/import_test.go
@@ -1,0 +1,37 @@
+package generator
+
+import (
+	gΩ "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestImport_String(t *testing.T) {
+	var testcases = []struct {
+		name     string
+		imp      Import
+		expected string
+	}{
+		{
+			name:     "stdlib package",
+			imp:      Import{Alias: "os", PkgPath: "os"},
+			expected: `"os"`,
+		},
+		{
+			name:     "alias matches base name",
+			imp:      Import{Alias: "foo", PkgPath: "example.com/goo/foo"},
+			expected: `"example.com/goo/foo"`,
+		},
+		{
+			name:     "custom package alias",
+			imp:      Import{Alias: "thinga", PkgPath: "example.com/go-thing"},
+			expected: `thinga "example.com/go-thing"`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := gΩ.NewGomegaWithT(t)
+			o.Expect(tc.imp.String()).To(gΩ.Equal(tc.expected))
+		})
+	}
+}

--- a/generator/interface_template.go
+++ b/generator/interface_template.go
@@ -5,7 +5,7 @@ import (
 	"text/template"
 )
 
-var interfaceFuncs template.FuncMap = template.FuncMap{
+var interfaceFuncs = template.FuncMap{
 	"ToLower":    strings.ToLower,
 	"UnExport":   unexport,
 	"Replace":    strings.Replace,
@@ -17,7 +17,7 @@ package {{.DestinationPackage}}
 
 import (
 	{{- range $index, $import := .Imports.ByAlias}}
-	{{$import.Alias}} "{{$import.PkgPath}}"
+	{{$import}}
 	{{- end}}
 )
 

--- a/generator/package_template.go
+++ b/generator/package_template.go
@@ -5,7 +5,7 @@ import (
 	"text/template"
 )
 
-var packageFuncs template.FuncMap = template.FuncMap{
+var packageFuncs = template.FuncMap{
 	"ToLower":  strings.ToLower,
 	"UnExport": unexport,
 	"Replace":  strings.Replace,
@@ -17,7 +17,7 @@ package {{.DestinationPackage}}
 
 import (
 	{{- range $index, $import := .Imports.ByAlias}}
-	{{$import.Alias}} "{{$import.PkgPath}}"
+	{{$import}}
 	{{- end}}
 )
 

--- a/integration/testdata/expected_fake_somethingfactory.txt
+++ b/integration/testdata/expected_fake_somethingfactory.txt
@@ -2,9 +2,9 @@
 package fixturesfakes
 
 import (
-	sync "sync"
+	"sync"
 
-	fixtures "github.com/maxbrunsfeld/counterfeiter/fixtures"
+	"github.com/maxbrunsfeld/counterfeiter/fixtures"
 )
 
 type FakeSomethingFactory struct {

--- a/integration/testdata/expected_fake_writecloser.txt
+++ b/integration/testdata/expected_fake_writecloser.txt
@@ -2,8 +2,8 @@
 package custom
 
 import (
-	io "io"
-	sync "sync"
+	"io"
+	"sync"
 )
 
 type FakeWriteCloser struct {


### PR DESCRIPTION
Branched from #109

Format the import line in `Import.String()` so that the template only needs to print the import and unnecessary aliases (where the alias is identical to the package path base) will not be added.