### PR TITLE
Imports for inline structs

### DIFF
--- a/fixtures/inline_struct_params.go
+++ b/fixtures/inline_struct_params.go
@@ -1,4 +1,4 @@
-package inlinestructs
+package fixtures
 
 import (
 	"context"
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-type SomeInterface interface {
+type InlineInterface interface {
 	DoSomething(ctx context.Context, body struct {
 		SomeString        string
 		SomeStringPointer *string

--- a/fixtures/inlinestructs/interface.go
+++ b/fixtures/inlinestructs/interface.go
@@ -1,0 +1,17 @@
+package inlinestructs
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+type SomeInterface interface {
+	DoSomething(ctx context.Context, body struct {
+		SomeString        string
+		SomeStringPointer *string
+		SomeTime          time.Time
+		SomeTimePointer   *time.Time
+		HTTPRequest       http.Request
+	}) error
+}

--- a/generator/loader.go
+++ b/generator/loader.go
@@ -131,6 +131,10 @@ func (f *Fake) addImportsFor(typ types.Type) {
 		return
 	case *types.Signature:
 		f.addTypesForMethod(t)
+	case *types.Struct:
+		for i := 0; i < t.NumFields(); i++ {
+			f.addImportsFor(t.Field(i).Type())
+		}
 	default:
 		log.Printf("!!! WARNING: Missing case for type %s\n", reflect.TypeOf(typ).String())
 	}


### PR DESCRIPTION
I recently encountered some odd behaviour when generating mocks for interfaces making use of anonymous / inline structs (as mentioned in this issue https://github.com/maxbrunsfeld/counterfeiter/issues/128).

This PR aims to address that issue.
- Updated the generator to recurse through struct fields and add imports for their types
- Added a text fixture for this kind of interface