### PR TITLE
Add go 1.11 directive to go.mod

### DIFF
--- a/command/runner_test.go
+++ b/command/runner_test.go
@@ -61,7 +61,7 @@ func testRunner(t *testing.T, when spec.G, it spec.S) {
 			i, err := command.Detect(filepath.Join(".", "..", "fixtures"), []string{"counterfeiter", ".", "AliasedInterface"}, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(i).NotTo(BeNil())
-			Expect(len(i)).To(Equal(17))
+			Expect(len(i)).To(Equal(18))
 			Expect(i[0].File).To(Equal("aliased_interfaces.go"))
 			Expect(i[0].Line).To(Equal(7))
 			Expect(i[0].Args).To(HaveLen(3))

--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
+
+go 1.11


### PR DESCRIPTION
Go 1.13 automatically adds `go 1.13` if it's missing,
which is wrong and breaks the test script too because it fails
if there are uncommitted changes.

Fixes #131