### PR TITLE
Fix importing of vendored packages

### DIFF
--- a/generator/loader.go
+++ b/generator/loader.go
@@ -2,8 +2,10 @@ package generator
 
 import (
 	"fmt"
+	"go/build"
 	"go/types"
 	"log"
+	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -19,11 +21,19 @@ func (f *Fake) loadPackages(c Cacher, workingDir string) error {
 		log.Printf("loaded %v packages from cache\n", len(f.Packages))
 		return nil
 	}
+	importPath := f.TargetPackage
+	if !filepath.IsAbs(importPath) {
+		bp, err := build.Import(f.TargetPackage, workingDir, build.FindOnly)
+		if err != nil {
+			return err
+		}
+		importPath = bp.ImportPath
+	}
 	p, err := packages.Load(&packages.Config{
 		Mode:  packages.NeedName | packages.NeedFiles | packages.NeedImports | packages.NeedDeps | packages.NeedTypes,
 		Dir:   workingDir,
 		Tests: true,
-	}, f.TargetPackage)
+	}, importPath)
 	if err != nil {
 		return err
 	}

--- a/integration/roundtrip_test.go
+++ b/integration/roundtrip_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"fmt"
+	"go/build"
 	"io/ioutil"
 	"log"
 	"os"
@@ -22,6 +23,7 @@ func runTests(useGopath bool, t *testing.T, when spec.G, it spec.S) {
 		baseDir             string
 		relativeDir         string
 		originalGopath      string
+		originalBuildGopath string
 		originalGo111module string
 		testDir             string
 		copyDirFunc         func()
@@ -44,11 +46,14 @@ func runTests(useGopath bool, t *testing.T, when spec.G, it spec.S) {
 			os.Setenv("GO111MODULE", "on")
 		}
 		originalGopath = os.Getenv("GOPATH")
+		originalBuildGopath = build.Default.GOPATH
 		var err error
 		testDir, err = ioutil.TempDir("", "counterfeiter-integration")
 		Expect(err).NotTo(HaveOccurred())
 		if useGopath {
 			os.Setenv("GOPATH", testDir)
+			// build.Default only reads the GOPATH env variable once on init
+			build.Default.GOPATH = testDir
 		} else {
 			os.Unsetenv("GOPATH")
 		}
@@ -103,6 +108,7 @@ func runTests(useGopath bool, t *testing.T, when spec.G, it spec.S) {
 		} else {
 			os.Unsetenv("GOPATH")
 		}
+		build.Default.GOPATH = originalBuildGopath
 		if baseDir == "" {
 			return
 		}


### PR DESCRIPTION
x/tools/go/packages does not search inside vendor.
Work around by using build.Import first to find the package in vendor.
See https://github.com/golang/go/issues/30289

There aren't any tests with a vendor directory, so I only tested this manually on a project that uses it and wants to generate a fake for a vendored package. I can try to write some test fixtures if you'd like.

Fixes #75 