### PR TITLE
Pick up go:generate directive changes

### DIFF
--- a/arguments/parser_test.go
+++ b/arguments/parser_test.go
@@ -14,7 +14,7 @@ import (
 
 	"testing"
 
-	"github.com/maxbrunsfeld/counterfeiter/v6/arguments"
+	"github.com/maxbrunsfeld/counterfeiter/arguments"
 
 	reporter "github.com/joefitzgerald/rainbow-reporter"
 	. "github.com/onsi/gomega"

--- a/arguments/parser_windows_test.go
+++ b/arguments/parser_windows_test.go
@@ -11,7 +11,7 @@ import (
 
 	"testing"
 
-	"github.com/maxbrunsfeld/counterfeiter/v6/arguments"
+	"github.com/maxbrunsfeld/counterfeiter/arguments"
 
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
@@ -24,12 +24,12 @@ func TestParsingArguments(t *testing.T) {
 
 func testParsingArguments(t *testing.T, when spec.G, it spec.S) {
 	var (
-		err error
+		err        error
 		parsedArgs *arguments.ParsedArguments
-		args []string
+		args       []string
 		workingDir string
-		evaler arguments.Evaler
-		stater arguments.Stater
+		evaler     arguments.Evaler
+		stater     arguments.Stater
 	)
 
 	justBefore := func() {

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/maxbrunsfeld/counterfeiter/v6/arguments"
-	"github.com/maxbrunsfeld/counterfeiter/v6/generator"
+	"github.com/maxbrunsfeld/counterfeiter/arguments"
+	"github.com/maxbrunsfeld/counterfeiter/generator"
 )
 
 func BenchmarkWithoutCache(b *testing.B) {

--- a/command/runner_test.go
+++ b/command/runner_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/maxbrunsfeld/counterfeiter/v6/command"
+	"github.com/maxbrunsfeld/counterfeiter/command"
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"

--- a/fixtures/aliased_interfaces.go
+++ b/fixtures/aliased_interfaces.go
@@ -1,6 +1,6 @@
 package fixtures
 
-import alias "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/another_package"
+import alias "github.com/maxbrunsfeld/counterfeiter/fixtures/another_package"
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . AliasedInterface
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate

--- a/fixtures/aliased_package/in_aliased_package.go
+++ b/fixtures/aliased_package/in_aliased_package.go
@@ -1,4 +1,4 @@
-package the_aliased_package // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/aliased_package"
+package the_aliased_package // import "github.com/maxbrunsfeld/counterfeiter/fixtures/aliased_package"
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . InAliasedPackage
 type InAliasedPackage interface {

--- a/fixtures/another_package/types.go
+++ b/fixtures/another_package/types.go
@@ -1,4 +1,4 @@
-package another_package // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/another_package"
+package another_package // import "github.com/maxbrunsfeld/counterfeiter/fixtures/another_package"
 
 type SomeType int
 

--- a/fixtures/blank.go
+++ b/fixtures/blank.go
@@ -1,1 +1,1 @@
-package fixtures // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures"
+package fixtures // import "github.com/maxbrunsfeld/counterfeiter/fixtures"

--- a/fixtures/dup_packages/a/a.go
+++ b/fixtures/dup_packages/a/a.go
@@ -1,6 +1,6 @@
-package a // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/a"
+package a // import "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/a"
 
-import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/a/foo"
+import "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/a/foo"
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . A
 type A interface {

--- a/fixtures/dup_packages/a/foo/a.go
+++ b/fixtures/dup_packages/a/foo/a.go
@@ -1,4 +1,4 @@
-package foo // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/a/foo"
+package foo // import "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/a/foo"
 
 type S struct{}
 

--- a/fixtures/dup_packages/alias.go
+++ b/fixtures/dup_packages/alias.go
@@ -1,9 +1,9 @@
-package dup_packages // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages"
+package dup_packages // import "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages"
 
 import (
-	"github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/a"
-	afoo "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/a/foo"
-	"github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/b/foo"
+	"github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/a"
+	afoo "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/a/foo"
+	"github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/b/foo"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate

--- a/fixtures/dup_packages/b/foo/b.go
+++ b/fixtures/dup_packages/b/foo/b.go
@@ -1,4 +1,4 @@
-package foo // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/b/foo"
+package foo // import "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/b/foo"
 
 type S struct{}
 

--- a/fixtures/dup_packages/dupA.go
+++ b/fixtures/dup_packages/dupA.go
@@ -1,6 +1,6 @@
-package dup_packages // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages"
+package dup_packages // import "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages"
 
-import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/a/foo"
+import "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/a/foo"
 
 //counterfeiter:generate . DupA
 type DupA interface {

--- a/fixtures/dup_packages/dupAB.go
+++ b/fixtures/dup_packages/dupAB.go
@@ -1,4 +1,4 @@
-package dup_packages // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages"
+package dup_packages // import "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages"
 
 //counterfeiter:generate . DupAB
 type DupAB interface {

--- a/fixtures/dup_packages/dupB.go
+++ b/fixtures/dup_packages/dupB.go
@@ -1,6 +1,6 @@
-package dup_packages // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages"
+package dup_packages // import "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages"
 
-import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/b/foo"
+import "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/b/foo"
 
 //counterfeiter:generate . DupB
 type DupB interface {

--- a/fixtures/dup_packages/dup_packagenames.go
+++ b/fixtures/dup_packages/dup_packagenames.go
@@ -1,8 +1,8 @@
-package dup_packages // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages"
+package dup_packages // import "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages"
 
 import (
-	"github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/a/foo"
-	bfoo "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/b/foo"
+	"github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/a/foo"
+	bfoo "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/b/foo"
 )
 
 //counterfeiter:generate . AB

--- a/fixtures/dup_packages/foo/multi_import.go
+++ b/fixtures/dup_packages/foo/multi_import.go
@@ -1,8 +1,8 @@
-package foo // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/foo"
+package foo // import "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/foo"
 
 import (
-	"github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/a/foo"
-	bfoo "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/b/foo"
+	"github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/a/foo"
+	bfoo "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/b/foo"
 )
 
 type S struct{}

--- a/fixtures/dup_packages/go.mod
+++ b/fixtures/dup_packages/go.mod
@@ -1,3 +1,3 @@
-module github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages
+module github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages
 
 go 1.12

--- a/fixtures/embeds_interfaces.go
+++ b/fixtures/embeds_interfaces.go
@@ -3,7 +3,7 @@ package fixtures
 import (
 	"net/http"
 
-	"github.com/maxbrunsfeld/counterfeiter/v6/fixtures/another_package"
+	"github.com/maxbrunsfeld/counterfeiter/fixtures/another_package"
 )
 
 //counterfeiter:generate . EmbedsInterfaces

--- a/fixtures/go-hyphenpackage/fixture.go
+++ b/fixtures/go-hyphenpackage/fixture.go
@@ -1,3 +1,3 @@
-package hyphenpackage // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/go-hyphenpackage"
+package hyphenpackage // import "github.com/maxbrunsfeld/counterfeiter/fixtures/go-hyphenpackage"
 
 type HyphenType struct{}

--- a/fixtures/hyphenated_package_same_name/go.mod
+++ b/fixtures/hyphenated_package_same_name/go.mod
@@ -1,1 +1,1 @@
-module github.com/maxbrunsfeld/counterfeiter/v6/fixtures/hyphenated_package_same_name
+module github.com/maxbrunsfeld/counterfeiter/fixtures/hyphenated_package_same_name

--- a/fixtures/hyphenated_package_same_name/hyphen-ated/some_package/types.go
+++ b/fixtures/hyphenated_package_same_name/hyphen-ated/some_package/types.go
@@ -1,3 +1,3 @@
-package some_package // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/hyphenated_package_same_name/hyphen-ated/some_package"
+package some_package // import "github.com/maxbrunsfeld/counterfeiter/fixtures/hyphenated_package_same_name/hyphen-ated/some_package"
 
 type Thing int

--- a/fixtures/hyphenated_package_same_name/some_package/interface.go
+++ b/fixtures/hyphenated_package_same_name/some_package/interface.go
@@ -1,6 +1,6 @@
-package some_package // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/hyphenated_package_same_name/some_package"
+package some_package // import "github.com/maxbrunsfeld/counterfeiter/fixtures/hyphenated_package_same_name/some_package"
 
-import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/hyphenated_package_same_name/hyphen-ated/some_package"
+import "github.com/maxbrunsfeld/counterfeiter/fixtures/hyphenated_package_same_name/hyphen-ated/some_package"
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . SomeInterface
 type SomeInterface interface {

--- a/fixtures/imports_go_hyphen_package.go
+++ b/fixtures/imports_go_hyphen_package.go
@@ -1,7 +1,7 @@
 package fixtures
 
 import (
-	"github.com/maxbrunsfeld/counterfeiter/v6/fixtures/go-hyphenpackage"
+	"github.com/maxbrunsfeld/counterfeiter/fixtures/go-hyphenpackage"
 )
 
 //counterfeiter:generate . ImportsGoHyphenPackage

--- a/fixtures/something_remote.go
+++ b/fixtures/something_remote.go
@@ -1,6 +1,6 @@
 package fixtures
 
-import the_aliased_package "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/aliased_package"
+import the_aliased_package "github.com/maxbrunsfeld/counterfeiter/fixtures/aliased_package"
 
 //counterfeiter:generate . SomethingWithForeignInterface
 

--- a/fixtures/sync/interface.go
+++ b/fixtures/sync/interface.go
@@ -1,4 +1,4 @@
-package sync // import "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/sync"
+package sync // import "github.com/maxbrunsfeld/counterfeiter/fixtures/sync"
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . SyncSomething
 type SyncSomething interface {

--- a/generated_fakes_test.go
+++ b/generated_fakes_test.go
@@ -5,8 +5,8 @@ import (
 
 	"testing"
 
-	"github.com/maxbrunsfeld/counterfeiter/v6/fixtures"
-	"github.com/maxbrunsfeld/counterfeiter/v6/fixtures/fixturesfakes"
+	"github.com/maxbrunsfeld/counterfeiter/fixtures"
+	"github.com/maxbrunsfeld/counterfeiter/fixtures/fixturesfakes"
 
 	reporter "github.com/joefitzgerald/rainbow-reporter"
 	. "github.com/onsi/gomega"

--- a/generator/generator_internals_test.go
+++ b/generator/generator_internals_test.go
@@ -119,21 +119,21 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 		when("duplicate import package names are added", func() {
 			it.Before(func() {
 				f.Imports.Add("sync", "sync")
-				f.Imports.Add("sync", "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/sync")
-				f.Imports.Add("sync", "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/othersync")
+				f.Imports.Add("sync", "github.com/maxbrunsfeld/counterfeiter/fixtures/sync")
+				f.Imports.Add("sync", "github.com/maxbrunsfeld/counterfeiter/fixtures/othersync")
 			})
 
 			it("all packages have unique aliases", func() {
 				Expect(f.Imports).To(BeEquivalentTo(Imports{
 					ByAlias: map[string]Import{
 						"sync":  {Alias: "sync", PkgPath: "sync"},
-						"synca": {Alias: "synca", PkgPath: "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/sync"},
-						"syncb": {Alias: "syncb", PkgPath: "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/othersync"},
+						"synca": {Alias: "synca", PkgPath: "github.com/maxbrunsfeld/counterfeiter/fixtures/sync"},
+						"syncb": {Alias: "syncb", PkgPath: "github.com/maxbrunsfeld/counterfeiter/fixtures/othersync"},
 					},
 					ByPkgPath: map[string]Import{
 						"sync": {Alias: "sync", PkgPath: "sync"},
-						"github.com/maxbrunsfeld/counterfeiter/v6/fixtures/sync":      {Alias: "synca", PkgPath: "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/sync"},
-						"github.com/maxbrunsfeld/counterfeiter/v6/fixtures/othersync": {Alias: "syncb", PkgPath: "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/othersync"},
+						"github.com/maxbrunsfeld/counterfeiter/fixtures/sync":      {Alias: "synca", PkgPath: "github.com/maxbrunsfeld/counterfeiter/fixtures/sync"},
+						"github.com/maxbrunsfeld/counterfeiter/fixtures/othersync": {Alias: "syncb", PkgPath: "github.com/maxbrunsfeld/counterfeiter/fixtures/othersync"},
 					},
 				}))
 			})
@@ -302,7 +302,7 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it("turns a vendor path into the correct import", func() {
-					i := f.Imports.Add("apackage", "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/vendored/vendor/apackage")
+					i := f.Imports.Add("apackage", "github.com/maxbrunsfeld/counterfeiter/fixtures/vendored/vendor/apackage")
 					Expect(i.Alias).To(Equal("apackage"))
 					Expect(i.PkgPath).To(Equal("apackage"))
 

--- a/integration/roundtrip_test.go
+++ b/integration/roundtrip_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
 
-	"github.com/maxbrunsfeld/counterfeiter/v6/generator"
+	"github.com/maxbrunsfeld/counterfeiter/generator"
 )
 
 func runTests(useGopath bool, t *testing.T, when spec.G, it spec.S) {
@@ -89,7 +89,7 @@ func runTests(useGopath bool, t *testing.T, when spec.G, it spec.S) {
 		}
 		initModuleFunc = func() {
 			copyFileFunc("blank.go")
-			err := ioutil.WriteFile(filepath.Join(baseDir, "go.mod"), []byte("module github.com/maxbrunsfeld/counterfeiter/v6/fixtures"), 0755)
+			err := ioutil.WriteFile(filepath.Join(baseDir, "go.mod"), []byte("module github.com/maxbrunsfeld/counterfeiter/fixtures"), 0755)
 			Expect(err).ToNot(HaveOccurred())
 		}
 		// Set this to true to write the output of tests to the testdata/output
@@ -172,10 +172,10 @@ func runTests(useGopath bool, t *testing.T, when spec.G, it spec.S) {
 						suffix = "/" + suffix
 					}
 					if !useGopath {
-						WriteOutput([]byte(fmt.Sprintf("module github.com/maxbrunsfeld/counterfeiter/v6/fixtures%s\n", suffix)), filepath.Join(baseDir, "go.mod"))
+						WriteOutput([]byte(fmt.Sprintf("module github.com/maxbrunsfeld/counterfeiter/fixtures%s\n", suffix)), filepath.Join(baseDir, "go.mod"))
 					}
 					cache := &generator.FakeCache{}
-					f, err := generator.NewFake(generator.InterfaceOrFunction, interfaceName, fmt.Sprintf("github.com/maxbrunsfeld/counterfeiter/v6/fixtures%s", suffix), "Fake"+interfaceName, "fixturesfakes", baseDir, cache)
+					f, err := generator.NewFake(generator.InterfaceOrFunction, interfaceName, fmt.Sprintf("github.com/maxbrunsfeld/counterfeiter/fixtures%s", suffix), "Fake"+interfaceName, "fixturesfakes", baseDir, cache)
 					Expect(err).NotTo(HaveOccurred())
 					b, err := f.Generate(true) // Flip to false to see output if goimports fails
 					Expect(err).NotTo(HaveOccurred())
@@ -218,7 +218,7 @@ func runTests(useGopath bool, t *testing.T, when spec.G, it spec.S) {
 					})
 
 					it("succeeds", func() {
-						pkgPath := "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages"
+						pkgPath := "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages"
 						if offset != "" {
 							pkgPath = pkgPath + "/" + offset
 						}

--- a/integration/testdata/expected_fake_multiab.txt
+++ b/integration/testdata/expected_fake_multiab.txt
@@ -4,9 +4,9 @@ package foofakes
 import (
 	"sync"
 
-	fooa "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/a/foo"
-	foob "github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/b/foo"
-	"github.com/maxbrunsfeld/counterfeiter/v6/fixtures/dup_packages/foo"
+	fooa "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/a/foo"
+	foob "github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/b/foo"
+	"github.com/maxbrunsfeld/counterfeiter/fixtures/dup_packages/foo"
 )
 
 type FakeMultiAB struct {

--- a/integration/testdata/expected_fake_somethingfactory.txt
+++ b/integration/testdata/expected_fake_somethingfactory.txt
@@ -4,7 +4,7 @@ package fixturesfakes
 import (
 	"sync"
 
-	"github.com/maxbrunsfeld/counterfeiter/v6/fixtures"
+	"github.com/maxbrunsfeld/counterfeiter/fixtures"
 )
 
 type FakeSomethingFactory struct {

--- a/main.go
+++ b/main.go
@@ -11,9 +11,9 @@ import (
 	"runtime/debug"
 	"runtime/pprof"
 
-	"github.com/maxbrunsfeld/counterfeiter/v6/arguments"
-	"github.com/maxbrunsfeld/counterfeiter/v6/command"
-	"github.com/maxbrunsfeld/counterfeiter/v6/generator"
+	"github.com/maxbrunsfeld/counterfeiter/arguments"
+	"github.com/maxbrunsfeld/counterfeiter/command"
+	"github.com/maxbrunsfeld/counterfeiter/generator"
 )
 
 func main() {


### PR DESCRIPTION
Counterfeiter had a bug which basically consumed any go:generate directive in its file, despite whether it's for counterfeiter or not.
This is to pick up the latest fixes from master

https://github.com/maxbrunsfeld/counterfeiter/commit/35e91c87cc60ec4244cccfba57cad556606c3c79