### PR TITLE
Avoid data race when accessing function stub

### DIFF
--- a/fixtures/aliased_package/aliased_packagefakes/fake_in_aliased_package.go
+++ b/fixtures/aliased_package/aliased_packagefakes/fake_in_aliased_package.go
@@ -30,9 +30,10 @@ func (fake *FakeInAliasedPackage) Stuff(arg1 int) string {
 		arg1 int
 	}{arg1})
 	fake.recordInvocation("Stuff", []interface{}{arg1})
+	stuffStubCopy := fake.StuffStub
 	fake.stuffMutex.Unlock()
-	if fake.StuffStub != nil {
-		return fake.StuffStub(arg1)
+	if stuffStubCopy != nil {
+		return stuffStubCopy(arg1)
 	}
 	if specificReturn {
 		return ret.result1

--- a/fixtures/another_package/another_packagefakes/fake_another_interface.go
+++ b/fixtures/another_package/another_packagefakes/fake_another_interface.go
@@ -36,9 +36,10 @@ func (fake *FakeAnotherInterface) AnotherMethod(arg1 []another_package.SomeType,
 		arg5 chan another_package.SomeType
 	}{arg1Copy, arg2, arg3, arg4, arg5})
 	fake.recordInvocation("AnotherMethod", []interface{}{arg1Copy, arg2, arg3, arg4, arg5})
+	anotherMethodStubCopy := fake.AnotherMethodStub
 	fake.anotherMethodMutex.Unlock()
-	if fake.AnotherMethodStub != nil {
-		fake.AnotherMethodStub(arg1, arg2, arg3, arg4, arg5)
+	if anotherMethodStubCopy != nil {
+		anotherMethodStubCopy(arg1, arg2, arg3, arg4, arg5)
 	}
 }
 

--- a/fixtures/fixturesfakes/fake_aliased_interface.go
+++ b/fixtures/fixturesfakes/fake_aliased_interface.go
@@ -37,9 +37,10 @@ func (fake *FakeAliasedInterface) AnotherMethod(arg1 []another_package.SomeType,
 		arg5 chan another_package.SomeType
 	}{arg1Copy, arg2, arg3, arg4, arg5})
 	fake.recordInvocation("AnotherMethod", []interface{}{arg1Copy, arg2, arg3, arg4, arg5})
+	anotherMethodStubCopy := fake.AnotherMethodStub
 	fake.anotherMethodMutex.Unlock()
-	if fake.AnotherMethodStub != nil {
-		fake.AnotherMethodStub(arg1, arg2, arg3, arg4, arg5)
+	if anotherMethodStubCopy != nil {
+		anotherMethodStubCopy(arg1, arg2, arg3, arg4, arg5)
 	}
 }
 

--- a/fixtures/fixturesfakes/fake_dot_imports.go
+++ b/fixtures/fixturesfakes/fake_dot_imports.go
@@ -35,9 +35,10 @@ func (fake *FakeDotImports) DoThings(arg1 io.Writer, arg2 *os.File) *http.Client
 		arg2 *os.File
 	}{arg1, arg2})
 	fake.recordInvocation("DoThings", []interface{}{arg1, arg2})
+	doThingsStubCopy := fake.DoThingsStub
 	fake.doThingsMutex.Unlock()
-	if fake.DoThingsStub != nil {
-		return fake.DoThingsStub(arg1, arg2)
+	if doThingsStubCopy != nil {
+		return doThingsStubCopy(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1

--- a/fixtures/fixturesfakes/fake_embeds_interfaces.go
+++ b/fixtures/fixturesfakes/fake_embeds_interfaces.go
@@ -58,9 +58,10 @@ func (fake *FakeEmbedsInterfaces) AnotherMethod(arg1 []another_package.SomeType,
 		arg5 chan another_package.SomeType
 	}{arg1Copy, arg2, arg3, arg4, arg5})
 	fake.recordInvocation("AnotherMethod", []interface{}{arg1Copy, arg2, arg3, arg4, arg5})
+	anotherMethodStubCopy := fake.AnotherMethodStub
 	fake.anotherMethodMutex.Unlock()
-	if fake.AnotherMethodStub != nil {
-		fake.AnotherMethodStub(arg1, arg2, arg3, arg4, arg5)
+	if anotherMethodStubCopy != nil {
+		anotherMethodStubCopy(arg1, arg2, arg3, arg4, arg5)
 	}
 }
 
@@ -88,9 +89,10 @@ func (fake *FakeEmbedsInterfaces) DoThings() {
 	fake.doThingsArgsForCall = append(fake.doThingsArgsForCall, struct {
 	}{})
 	fake.recordInvocation("DoThings", []interface{}{})
+	doThingsStubCopy := fake.DoThingsStub
 	fake.doThingsMutex.Unlock()
-	if fake.DoThingsStub != nil {
-		fake.DoThingsStub()
+	if doThingsStubCopy != nil {
+		doThingsStubCopy()
 	}
 }
 
@@ -112,9 +114,10 @@ func (fake *FakeEmbedsInterfaces) EmbeddedMethod() string {
 	fake.embeddedMethodArgsForCall = append(fake.embeddedMethodArgsForCall, struct {
 	}{})
 	fake.recordInvocation("EmbeddedMethod", []interface{}{})
+	embeddedMethodStubCopy := fake.EmbeddedMethodStub
 	fake.embeddedMethodMutex.Unlock()
-	if fake.EmbeddedMethodStub != nil {
-		return fake.EmbeddedMethodStub()
+	if embeddedMethodStubCopy != nil {
+		return embeddedMethodStubCopy()
 	}
 	if specificReturn {
 		return ret.result1
@@ -165,9 +168,10 @@ func (fake *FakeEmbedsInterfaces) ServeHTTP(arg1 http.ResponseWriter, arg2 *http
 		arg2 *http.Request
 	}{arg1, arg2})
 	fake.recordInvocation("ServeHTTP", []interface{}{arg1, arg2})
+	serveHTTPStubCopy := fake.ServeHTTPStub
 	fake.serveHTTPMutex.Unlock()
-	if fake.ServeHTTPStub != nil {
-		fake.ServeHTTPStub(arg1, arg2)
+	if serveHTTPStubCopy != nil {
+		serveHTTPStubCopy(arg1, arg2)
 	}
 }
 

--- a/fixtures/fixturesfakes/fake_first_interface.go
+++ b/fixtures/fixturesfakes/fake_first_interface.go
@@ -21,9 +21,10 @@ func (fake *FakeFirstInterface) DoThings() {
 	fake.doThingsArgsForCall = append(fake.doThingsArgsForCall, struct {
 	}{})
 	fake.recordInvocation("DoThings", []interface{}{})
+	doThingsStubCopy := fake.DoThingsStub
 	fake.doThingsMutex.Unlock()
-	if fake.DoThingsStub != nil {
-		fake.DoThingsStub()
+	if doThingsStubCopy != nil {
+		doThingsStubCopy()
 	}
 }
 

--- a/fixtures/fixturesfakes/fake_has_imports.go
+++ b/fixtures/fixturesfakes/fake_has_imports.go
@@ -35,9 +35,10 @@ func (fake *FakeHasImports) DoThings(arg1 io.Writer, arg2 *os.File) *http.Client
 		arg2 *os.File
 	}{arg1, arg2})
 	fake.recordInvocation("DoThings", []interface{}{arg1, arg2})
+	doThingsStubCopy := fake.DoThingsStub
 	fake.doThingsMutex.Unlock()
-	if fake.DoThingsStub != nil {
-		return fake.DoThingsStub(arg1, arg2)
+	if doThingsStubCopy != nil {
+		return doThingsStubCopy(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1

--- a/fixtures/fixturesfakes/fake_has_other_types.go
+++ b/fixtures/fixturesfakes/fake_has_other_types.go
@@ -30,9 +30,10 @@ func (fake *FakeHasOtherTypes) GetThing(arg1 fixtures.SomeString) fixtures.SomeF
 		arg1 fixtures.SomeString
 	}{arg1})
 	fake.recordInvocation("GetThing", []interface{}{arg1})
+	getThingStubCopy := fake.GetThingStub
 	fake.getThingMutex.Unlock()
-	if fake.GetThingStub != nil {
-		return fake.GetThingStub(arg1)
+	if getThingStubCopy != nil {
+		return getThingStubCopy(arg1)
 	}
 	if specificReturn {
 		return ret.result1

--- a/fixtures/fixturesfakes/fake_has_var_args.go
+++ b/fixtures/fixturesfakes/fake_has_var_args.go
@@ -46,9 +46,10 @@ func (fake *FakeHasVarArgs) DoMoreThings(arg1 int, arg2 int, arg3 ...string) int
 		arg3 []string
 	}{arg1, arg2, arg3})
 	fake.recordInvocation("DoMoreThings", []interface{}{arg1, arg2, arg3})
+	doMoreThingsStubCopy := fake.DoMoreThingsStub
 	fake.doMoreThingsMutex.Unlock()
-	if fake.DoMoreThingsStub != nil {
-		return fake.DoMoreThingsStub(arg1, arg2, arg3...)
+	if doMoreThingsStubCopy != nil {
+		return doMoreThingsStubCopy(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
@@ -107,9 +108,10 @@ func (fake *FakeHasVarArgs) DoThings(arg1 int, arg2 ...string) int {
 		arg2 []string
 	}{arg1, arg2})
 	fake.recordInvocation("DoThings", []interface{}{arg1, arg2})
+	doThingsStubCopy := fake.DoThingsStub
 	fake.doThingsMutex.Unlock()
-	if fake.DoThingsStub != nil {
-		return fake.DoThingsStub(arg1, arg2...)
+	if doThingsStubCopy != nil {
+		return doThingsStubCopy(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1

--- a/fixtures/fixturesfakes/fake_has_var_args_with_local_types.go
+++ b/fixtures/fixturesfakes/fake_has_var_args_with_local_types.go
@@ -23,9 +23,10 @@ func (fake *FakeHasVarArgsWithLocalTypes) DoThings(arg1 ...fixtures.LocalType) {
 		arg1 []fixtures.LocalType
 	}{arg1})
 	fake.recordInvocation("DoThings", []interface{}{arg1})
+	doThingsStubCopy := fake.DoThingsStub
 	fake.doThingsMutex.Unlock()
-	if fake.DoThingsStub != nil {
-		fake.DoThingsStub(arg1...)
+	if doThingsStubCopy != nil {
+		doThingsStubCopy(arg1...)
 	}
 }
 

--- a/fixtures/fixturesfakes/fake_imports_go_hyphen_package.go
+++ b/fixtures/fixturesfakes/fake_imports_go_hyphen_package.go
@@ -24,9 +24,10 @@ func (fake *FakeImportsGoHyphenPackage) UseHyphenType(arg1 hyphenpackage.HyphenT
 		arg1 hyphenpackage.HyphenType
 	}{arg1})
 	fake.recordInvocation("UseHyphenType", []interface{}{arg1})
+	useHyphenTypeStubCopy := fake.UseHyphenTypeStub
 	fake.useHyphenTypeMutex.Unlock()
-	if fake.UseHyphenTypeStub != nil {
-		fake.UseHyphenTypeStub(arg1)
+	if useHyphenTypeStubCopy != nil {
+		useHyphenTypeStubCopy(arg1)
 	}
 }
 

--- a/fixtures/fixturesfakes/fake_inline_struct_params.go
+++ b/fixtures/fixturesfakes/fake_inline_struct_params.go
@@ -59,9 +59,10 @@ func (fake *FakeInlineStructParams) DoSomething(arg1 context.Context, arg2 struc
 		}
 	}{arg1, arg2})
 	fake.recordInvocation("DoSomething", []interface{}{arg1, arg2})
+	doSomethingStubCopy := fake.DoSomethingStub
 	fake.doSomethingMutex.Unlock()
-	if fake.DoSomethingStub != nil {
-		return fake.DoSomethingStub(arg1, arg2)
+	if doSomethingStubCopy != nil {
+		return doSomethingStubCopy(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1

--- a/fixtures/fixturesfakes/fake_reuses_arg_types.go
+++ b/fixtures/fixturesfakes/fake_reuses_arg_types.go
@@ -25,9 +25,10 @@ func (fake *FakeReusesArgTypes) DoThings(arg1 string, arg2 string) {
 		arg2 string
 	}{arg1, arg2})
 	fake.recordInvocation("DoThings", []interface{}{arg1, arg2})
+	doThingsStubCopy := fake.DoThingsStub
 	fake.doThingsMutex.Unlock()
-	if fake.DoThingsStub != nil {
-		fake.DoThingsStub(arg1, arg2)
+	if doThingsStubCopy != nil {
+		doThingsStubCopy(arg1, arg2)
 	}
 }
 

--- a/fixtures/fixturesfakes/fake_second_interface.go
+++ b/fixtures/fixturesfakes/fake_second_interface.go
@@ -28,9 +28,10 @@ func (fake *FakeSecondInterface) EmbeddedMethod() string {
 	fake.embeddedMethodArgsForCall = append(fake.embeddedMethodArgsForCall, struct {
 	}{})
 	fake.recordInvocation("EmbeddedMethod", []interface{}{})
+	embeddedMethodStubCopy := fake.EmbeddedMethodStub
 	fake.embeddedMethodMutex.Unlock()
-	if fake.EmbeddedMethodStub != nil {
-		return fake.EmbeddedMethodStub()
+	if embeddedMethodStubCopy != nil {
+		return embeddedMethodStubCopy()
 	}
 	if specificReturn {
 		return ret.result1

--- a/fixtures/fixturesfakes/fake_something.go
+++ b/fixtures/fixturesfakes/fake_something.go
@@ -51,9 +51,10 @@ func (fake *FakeSomething) DoASlice(arg1 []byte) {
 		arg1 []byte
 	}{arg1Copy})
 	fake.recordInvocation("DoASlice", []interface{}{arg1Copy})
+	doASliceStubCopy := fake.DoASliceStub
 	fake.doASliceMutex.Unlock()
-	if fake.DoASliceStub != nil {
-		fake.DoASliceStub(arg1)
+	if doASliceStubCopy != nil {
+		doASliceStubCopy(arg1)
 	}
 }
 
@@ -82,9 +83,10 @@ func (fake *FakeSomething) DoAnArray(arg1 [4]byte) {
 		arg1 [4]byte
 	}{arg1})
 	fake.recordInvocation("DoAnArray", []interface{}{arg1})
+	doAnArrayStubCopy := fake.DoAnArrayStub
 	fake.doAnArrayMutex.Unlock()
-	if fake.DoAnArrayStub != nil {
-		fake.DoAnArrayStub(arg1)
+	if doAnArrayStubCopy != nil {
+		doAnArrayStubCopy(arg1)
 	}
 }
 
@@ -112,9 +114,10 @@ func (fake *FakeSomething) DoNothing() {
 	fake.doNothingArgsForCall = append(fake.doNothingArgsForCall, struct {
 	}{})
 	fake.recordInvocation("DoNothing", []interface{}{})
+	doNothingStubCopy := fake.DoNothingStub
 	fake.doNothingMutex.Unlock()
-	if fake.DoNothingStub != nil {
-		fake.DoNothingStub()
+	if doNothingStubCopy != nil {
+		doNothingStubCopy()
 	}
 }
 
@@ -138,9 +141,10 @@ func (fake *FakeSomething) DoThings(arg1 string, arg2 uint64) (int, error) {
 		arg2 uint64
 	}{arg1, arg2})
 	fake.recordInvocation("DoThings", []interface{}{arg1, arg2})
+	doThingsStubCopy := fake.DoThingsStub
 	fake.doThingsMutex.Unlock()
-	if fake.DoThingsStub != nil {
-		return fake.DoThingsStub(arg1, arg2)
+	if doThingsStubCopy != nil {
+		return doThingsStubCopy(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2

--- a/fixtures/fixturesfakes/fake_something_else.go
+++ b/fixtures/fixturesfakes/fake_something_else.go
@@ -30,9 +30,10 @@ func (fake *FakeSomethingElse) ReturnStuff() (int, int) {
 	fake.returnStuffArgsForCall = append(fake.returnStuffArgsForCall, struct {
 	}{})
 	fake.recordInvocation("ReturnStuff", []interface{}{})
+	returnStuffStubCopy := fake.ReturnStuffStub
 	fake.returnStuffMutex.Unlock()
-	if fake.ReturnStuffStub != nil {
-		return fake.ReturnStuffStub()
+	if returnStuffStubCopy != nil {
+		return returnStuffStubCopy()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2

--- a/fixtures/fixturesfakes/fake_something_factory.go
+++ b/fixtures/fixturesfakes/fake_something_factory.go
@@ -32,9 +32,10 @@ func (fake *FakeSomethingFactory) Spy(arg1 string, arg2 map[string]interface{}) 
 		arg2 map[string]interface{}
 	}{arg1, arg2})
 	fake.recordInvocation("SomethingFactory", []interface{}{arg1, arg2})
+	stubCopy := fake.Stub
 	fake.mutex.Unlock()
-	if fake.Stub != nil {
-		return fake.Stub(arg1, arg2)
+	if stubCopy != nil {
+		return stubCopy(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1

--- a/fixtures/fixturesfakes/fake_something_with_foreign_interface.go
+++ b/fixtures/fixturesfakes/fake_something_with_foreign_interface.go
@@ -30,9 +30,10 @@ func (fake *FakeSomethingWithForeignInterface) Stuff(arg1 int) string {
 		arg1 int
 	}{arg1})
 	fake.recordInvocation("Stuff", []interface{}{arg1})
+	stuffStubCopy := fake.StuffStub
 	fake.stuffMutex.Unlock()
-	if fake.StuffStub != nil {
-		return fake.StuffStub(arg1)
+	if stuffStubCopy != nil {
+		return stuffStubCopy(arg1)
 	}
 	if specificReturn {
 		return ret.result1

--- a/fixtures/fixturesfakes/fake_unexported_func.go
+++ b/fixtures/fixturesfakes/fake_unexported_func.go
@@ -30,9 +30,10 @@ func (fake *FakeUnexportedFunc) Spy(arg1 string, arg2 map[string]interface{}) st
 		arg2 map[string]interface{}
 	}{arg1, arg2})
 	fake.recordInvocation("unexportedFunc", []interface{}{arg1, arg2})
+	stubCopy := fake.Stub
 	fake.mutex.Unlock()
-	if fake.Stub != nil {
-		return fake.Stub(arg1, arg2)
+	if stubCopy != nil {
+		return stubCopy(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1

--- a/fixtures/fixturesfakes/fake_unexported_interface.go
+++ b/fixtures/fixturesfakes/fake_unexported_interface.go
@@ -30,9 +30,10 @@ func (fake *FakeUnexportedInterface) Method(arg1 string, arg2 map[string]interfa
 		arg2 map[string]interface{}
 	}{arg1, arg2})
 	fake.recordInvocation("Method", []interface{}{arg1, arg2})
+	methodStubCopy := fake.MethodStub
 	fake.methodMutex.Unlock()
-	if fake.MethodStub != nil {
-		return fake.MethodStub(arg1, arg2)
+	if methodStubCopy != nil {
+		return methodStubCopy(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1

--- a/fixtures/sql/sqlfakes/fake_db.go
+++ b/fixtures/sql/sqlfakes/fake_db.go
@@ -35,9 +35,10 @@ func (fake *FakeDB) Exec(arg1 string, arg2 ...interface{}) (sqla.Result, error) 
 		arg2 []interface{}
 	}{arg1, arg2})
 	fake.recordInvocation("Exec", []interface{}{arg1, arg2})
+	execStubCopy := fake.ExecStub
 	fake.execMutex.Unlock()
-	if fake.ExecStub != nil {
-		return fake.ExecStub(arg1, arg2...)
+	if execStubCopy != nil {
+		return execStubCopy(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2

--- a/fixtures/sync/syncfakes/fake_sync_something.go
+++ b/fixtures/sync/syncfakes/fake_sync_something.go
@@ -51,9 +51,10 @@ func (fake *FakeSyncSomething) DoASlice(arg1 []byte) {
 		arg1 []byte
 	}{arg1Copy})
 	fake.recordInvocation("DoASlice", []interface{}{arg1Copy})
+	doASliceStubCopy := fake.DoASliceStub
 	fake.doASliceMutex.Unlock()
-	if fake.DoASliceStub != nil {
-		fake.DoASliceStub(arg1)
+	if doASliceStubCopy != nil {
+		doASliceStubCopy(arg1)
 	}
 }
 
@@ -82,9 +83,10 @@ func (fake *FakeSyncSomething) DoAnArray(arg1 [4]byte) {
 		arg1 [4]byte
 	}{arg1})
 	fake.recordInvocation("DoAnArray", []interface{}{arg1})
+	doAnArrayStubCopy := fake.DoAnArrayStub
 	fake.doAnArrayMutex.Unlock()
-	if fake.DoAnArrayStub != nil {
-		fake.DoAnArrayStub(arg1)
+	if doAnArrayStubCopy != nil {
+		doAnArrayStubCopy(arg1)
 	}
 }
 
@@ -112,9 +114,10 @@ func (fake *FakeSyncSomething) DoNothing() {
 	fake.doNothingArgsForCall = append(fake.doNothingArgsForCall, struct {
 	}{})
 	fake.recordInvocation("DoNothing", []interface{}{})
+	doNothingStubCopy := fake.DoNothingStub
 	fake.doNothingMutex.Unlock()
-	if fake.DoNothingStub != nil {
-		fake.DoNothingStub()
+	if doNothingStubCopy != nil {
+		doNothingStubCopy()
 	}
 }
 
@@ -138,9 +141,10 @@ func (fake *FakeSyncSomething) DoThings(arg1 string, arg2 uint64) (int, error) {
 		arg2 uint64
 	}{arg1, arg2})
 	fake.recordInvocation("DoThings", []interface{}{arg1, arg2})
+	doThingsStubCopy := fake.DoThingsStub
 	fake.doThingsMutex.Unlock()
-	if fake.DoThingsStub != nil {
-		return fake.DoThingsStub(arg1, arg2)
+	if doThingsStubCopy != nil {
+		return doThingsStubCopy(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2

--- a/generator/function_template.go
+++ b/generator/function_template.go
@@ -61,9 +61,10 @@ func (fake *{{.Name}}) Spy({{.Function.Params.AsNamedArgsWithTypes}}) {{.Functio
 		{{- end}}
 	}{ {{- .Function.Params.AsNamedArgs -}} })
 	fake.recordInvocation("{{.TargetName}}", []interface{}{ {{- if .Function.Params.HasLength}}{{.Function.Params.AsNamedArgs}}{{end -}} })
+	stubCopy := fake.Stub
 	fake.mutex.Unlock()
-	if fake.Stub != nil {
-		{{if .Function.Returns.HasLength}}return fake.Stub({{.Function.Params.AsNamedArgsForInvocation}}){{else}}fake.Stub({{.Function.Params.AsNamedArgsForInvocation}}){{end}}
+	if stubCopy != nil {
+		{{if .Function.Returns.HasLength}}return stubCopy({{.Function.Params.AsNamedArgsForInvocation}}){{else}}stubCopy({{.Function.Params.AsNamedArgsForInvocation}}){{end}}
 	}
 	{{- if .Function.Returns.HasLength}}
 	if specificReturn {

--- a/generator/interface_template.go
+++ b/generator/interface_template.go
@@ -67,10 +67,11 @@ func (fake *{{$.Name}}) {{.Name}}({{.Params.AsNamedArgsWithTypes}}) {{.Returns.A
 		{{- end}}
 	}{ {{- .Params.AsNamedArgs -}} })
 	fake.recordInvocation("{{.Name}}", []interface{}{ {{- if .Params.HasLength}}{{.Params.AsNamedArgs}}{{end -}} })
+	{{UnExport .Name}}StubCopy := fake.{{.Name}}Stub
 	fake.{{UnExport .Name}}Mutex.Unlock()
-	if fake.{{.Name}}Stub != nil {
+	if {{UnExport .Name}}StubCopy != nil {
 		{{- if .Returns.HasLength}}
-		return fake.{{.Name}}Stub({{.Params.AsNamedArgsForInvocation}}){{else}}fake.{{.Name}}Stub({{.Params.AsNamedArgsForInvocation}})
+		return {{UnExport .Name}}StubCopy({{.Params.AsNamedArgsForInvocation}}){{else}}{{UnExport .Name}}StubCopy({{.Params.AsNamedArgsForInvocation}})
 		{{- end}}
 	}
 	{{- if .Returns.HasLength}}

--- a/integration/testdata/expected_fake_multiab.txt
+++ b/integration/testdata/expected_fake_multiab.txt
@@ -46,9 +46,10 @@ func (fake *FakeMultiAB) Mine() foo.S {
 	ret, specificReturn := fake.mineReturnsOnCall[len(fake.mineArgsForCall)]
 	fake.mineArgsForCall = append(fake.mineArgsForCall, struct{}{})
 	fake.recordInvocation("Mine", []interface{}{})
+	mineStubCopy := fake.MineStub
 	fake.mineMutex.Unlock()
-	if fake.MineStub != nil {
-		return fake.MineStub()
+	if mineStubCopy != nil {
+		return mineStubCopy()
 	}
 	if specificReturn {
 		return ret.result1
@@ -96,9 +97,10 @@ func (fake *FakeMultiAB) FromA() fooa.S {
 	ret, specificReturn := fake.fromAReturnsOnCall[len(fake.fromAArgsForCall)]
 	fake.fromAArgsForCall = append(fake.fromAArgsForCall, struct{}{})
 	fake.recordInvocation("FromA", []interface{}{})
+	fromAStubCopy := fake.FromAStub
 	fake.fromAMutex.Unlock()
-	if fake.FromAStub != nil {
-		return fake.FromAStub()
+	if fromAStubCopy != nil {
+		return fromAStubCopy()
 	}
 	if specificReturn {
 		return ret.result1
@@ -146,9 +148,10 @@ func (fake *FakeMultiAB) FromB() foob.S {
 	ret, specificReturn := fake.fromBReturnsOnCall[len(fake.fromBArgsForCall)]
 	fake.fromBArgsForCall = append(fake.fromBArgsForCall, struct{}{})
 	fake.recordInvocation("FromB", []interface{}{})
+	fromBStubCopy := fake.FromBStub
 	fake.fromBMutex.Unlock()
-	if fake.FromBStub != nil {
-		return fake.FromBStub()
+	if fromBStubCopy != nil {
+		return fromBStubCopy()
 	}
 	if specificReturn {
 		return ret.result1

--- a/integration/testdata/expected_fake_somethingfactory.txt
+++ b/integration/testdata/expected_fake_somethingfactory.txt
@@ -32,9 +32,10 @@ func (fake *FakeSomethingFactory) Spy(arg1 string, arg2 map[string]interface{}) 
 		arg2 map[string]interface{}
 	}{arg1, arg2})
 	fake.recordInvocation("SomethingFactory", []interface{}{arg1, arg2})
+	stubCopy := fake.Stub
 	fake.mutex.Unlock()
-	if fake.Stub != nil {
-		return fake.Stub(arg1, arg2)
+	if stubCopy != nil {
+		return stubCopy(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1

--- a/integration/testdata/expected_fake_writecloser.noheader.txt
+++ b/integration/testdata/expected_fake_writecloser.noheader.txt
@@ -40,9 +40,10 @@ func (fake *FakeWriteCloser) Close() error {
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
 	fake.recordInvocation("Close", []interface{}{})
+	closeStubCopy := fake.CloseStub
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
+	if closeStubCopy != nil {
+		return closeStubCopy()
 	}
 	if specificReturn {
 		return ret.result1
@@ -98,9 +99,10 @@ func (fake *FakeWriteCloser) Write(arg1 []byte) (int, error) {
 		arg1 []byte
 	}{arg1Copy})
 	fake.recordInvocation("Write", []interface{}{arg1Copy})
+	writeStubCopy := fake.WriteStub
 	fake.writeMutex.Unlock()
-	if fake.WriteStub != nil {
-		return fake.WriteStub(arg1)
+	if writeStubCopy != nil {
+		return writeStubCopy(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2


### PR DESCRIPTION
Mutex is getting unlocked before the stub is read. This results in
data race when stub is being set to nil in FunctionReturnsOnCall. Use
the stub copy to release lock early and avoid data race.

Example in our tests we are seeing the following error:
```
WARNING: DATA RACE
Write at 0x00c0002ec450 by goroutine 20:
  code.cloudfoundry.org/executor/fakes.(*FakeClient).ListContainersReturnsOnCall()
      /tmp/build/80754af9/diego-release/src/code.cloudfoundry.org/executor/fakes/fake_client.go:665 +0xaf
...
Previous read at 0x00c0002ec450 by goroutine 63:
  code.cloudfoundry.org/executor/fakes.(*FakeClient).ListContainers()
      /tmp/build/80754af9/diego-release/src/code.cloudfoundry.org/executor/fakes/fake_client.go:623 +0x33c
```

Here the lines referred:
write - https://github.com/cloudfoundry/executor/blob/c2e45ac35e4cf291b091c066856a760796bd6c96/fakes/fake_client.go#L665
read - https://github.com/cloudfoundry/executor/blob/c2e45ac35e4cf291b091c066856a760796bd6c96/fakes/fake_client.go#L623