### PR TITLE
 Defer unlocks in fake function and interface calls

### DIFF
--- a/fixtures/aliased_package/aliased_packagefakes/fake_in_aliased_package.go
+++ b/fixtures/aliased_package/aliased_packagefakes/fake_in_aliased_package.go
@@ -25,12 +25,12 @@ type FakeInAliasedPackage struct {
 
 func (fake *FakeInAliasedPackage) Stuff(arg1 int) string {
 	fake.stuffMutex.Lock()
+	defer fake.stuffMutex.Unlock()
 	ret, specificReturn := fake.stuffReturnsOnCall[len(fake.stuffArgsForCall)]
 	fake.stuffArgsForCall = append(fake.stuffArgsForCall, struct {
 		arg1 int
 	}{arg1})
 	fake.recordInvocation("Stuff", []interface{}{arg1})
-	fake.stuffMutex.Unlock()
 	if fake.StuffStub != nil {
 		return fake.StuffStub(arg1)
 	}

--- a/fixtures/another_package/another_packagefakes/fake_another_interface.go
+++ b/fixtures/another_package/another_packagefakes/fake_another_interface.go
@@ -28,6 +28,7 @@ func (fake *FakeAnotherInterface) AnotherMethod(arg1 []another_package.SomeType,
 		copy(arg1Copy, arg1)
 	}
 	fake.anotherMethodMutex.Lock()
+	defer fake.anotherMethodMutex.Unlock()
 	fake.anotherMethodArgsForCall = append(fake.anotherMethodArgsForCall, struct {
 		arg1 []another_package.SomeType
 		arg2 map[another_package.SomeType]another_package.SomeType
@@ -36,7 +37,6 @@ func (fake *FakeAnotherInterface) AnotherMethod(arg1 []another_package.SomeType,
 		arg5 chan another_package.SomeType
 	}{arg1Copy, arg2, arg3, arg4, arg5})
 	fake.recordInvocation("AnotherMethod", []interface{}{arg1Copy, arg2, arg3, arg4, arg5})
-	fake.anotherMethodMutex.Unlock()
 	if fake.AnotherMethodStub != nil {
 		fake.AnotherMethodStub(arg1, arg2, arg3, arg4, arg5)
 	}

--- a/fixtures/fixturesfakes/fake_aliased_interface.go
+++ b/fixtures/fixturesfakes/fake_aliased_interface.go
@@ -29,6 +29,7 @@ func (fake *FakeAliasedInterface) AnotherMethod(arg1 []another_package.SomeType,
 		copy(arg1Copy, arg1)
 	}
 	fake.anotherMethodMutex.Lock()
+	defer fake.anotherMethodMutex.Unlock()
 	fake.anotherMethodArgsForCall = append(fake.anotherMethodArgsForCall, struct {
 		arg1 []another_package.SomeType
 		arg2 map[another_package.SomeType]another_package.SomeType
@@ -37,7 +38,6 @@ func (fake *FakeAliasedInterface) AnotherMethod(arg1 []another_package.SomeType,
 		arg5 chan another_package.SomeType
 	}{arg1Copy, arg2, arg3, arg4, arg5})
 	fake.recordInvocation("AnotherMethod", []interface{}{arg1Copy, arg2, arg3, arg4, arg5})
-	fake.anotherMethodMutex.Unlock()
 	if fake.AnotherMethodStub != nil {
 		fake.AnotherMethodStub(arg1, arg2, arg3, arg4, arg5)
 	}

--- a/fixtures/fixturesfakes/fake_dot_imports.go
+++ b/fixtures/fixturesfakes/fake_dot_imports.go
@@ -29,13 +29,13 @@ type FakeDotImports struct {
 
 func (fake *FakeDotImports) DoThings(arg1 io.Writer, arg2 *os.File) *http.Client {
 	fake.doThingsMutex.Lock()
+	defer fake.doThingsMutex.Unlock()
 	ret, specificReturn := fake.doThingsReturnsOnCall[len(fake.doThingsArgsForCall)]
 	fake.doThingsArgsForCall = append(fake.doThingsArgsForCall, struct {
 		arg1 io.Writer
 		arg2 *os.File
 	}{arg1, arg2})
 	fake.recordInvocation("DoThings", []interface{}{arg1, arg2})
-	fake.doThingsMutex.Unlock()
 	if fake.DoThingsStub != nil {
 		return fake.DoThingsStub(arg1, arg2)
 	}

--- a/fixtures/fixturesfakes/fake_embeds_interfaces.go
+++ b/fixtures/fixturesfakes/fake_embeds_interfaces.go
@@ -50,6 +50,7 @@ func (fake *FakeEmbedsInterfaces) AnotherMethod(arg1 []another_package.SomeType,
 		copy(arg1Copy, arg1)
 	}
 	fake.anotherMethodMutex.Lock()
+	defer fake.anotherMethodMutex.Unlock()
 	fake.anotherMethodArgsForCall = append(fake.anotherMethodArgsForCall, struct {
 		arg1 []another_package.SomeType
 		arg2 map[another_package.SomeType]another_package.SomeType
@@ -58,7 +59,6 @@ func (fake *FakeEmbedsInterfaces) AnotherMethod(arg1 []another_package.SomeType,
 		arg5 chan another_package.SomeType
 	}{arg1Copy, arg2, arg3, arg4, arg5})
 	fake.recordInvocation("AnotherMethod", []interface{}{arg1Copy, arg2, arg3, arg4, arg5})
-	fake.anotherMethodMutex.Unlock()
 	if fake.AnotherMethodStub != nil {
 		fake.AnotherMethodStub(arg1, arg2, arg3, arg4, arg5)
 	}
@@ -85,10 +85,10 @@ func (fake *FakeEmbedsInterfaces) AnotherMethodArgsForCall(i int) ([]another_pac
 
 func (fake *FakeEmbedsInterfaces) DoThings() {
 	fake.doThingsMutex.Lock()
+	defer fake.doThingsMutex.Unlock()
 	fake.doThingsArgsForCall = append(fake.doThingsArgsForCall, struct {
 	}{})
 	fake.recordInvocation("DoThings", []interface{}{})
-	fake.doThingsMutex.Unlock()
 	if fake.DoThingsStub != nil {
 		fake.DoThingsStub()
 	}
@@ -108,11 +108,11 @@ func (fake *FakeEmbedsInterfaces) DoThingsCalls(stub func()) {
 
 func (fake *FakeEmbedsInterfaces) EmbeddedMethod() string {
 	fake.embeddedMethodMutex.Lock()
+	defer fake.embeddedMethodMutex.Unlock()
 	ret, specificReturn := fake.embeddedMethodReturnsOnCall[len(fake.embeddedMethodArgsForCall)]
 	fake.embeddedMethodArgsForCall = append(fake.embeddedMethodArgsForCall, struct {
 	}{})
 	fake.recordInvocation("EmbeddedMethod", []interface{}{})
-	fake.embeddedMethodMutex.Unlock()
 	if fake.EmbeddedMethodStub != nil {
 		return fake.EmbeddedMethodStub()
 	}
@@ -160,12 +160,12 @@ func (fake *FakeEmbedsInterfaces) EmbeddedMethodReturnsOnCall(i int, result1 str
 
 func (fake *FakeEmbedsInterfaces) ServeHTTP(arg1 http.ResponseWriter, arg2 *http.Request) {
 	fake.serveHTTPMutex.Lock()
+	defer fake.serveHTTPMutex.Unlock()
 	fake.serveHTTPArgsForCall = append(fake.serveHTTPArgsForCall, struct {
 		arg1 http.ResponseWriter
 		arg2 *http.Request
 	}{arg1, arg2})
 	fake.recordInvocation("ServeHTTP", []interface{}{arg1, arg2})
-	fake.serveHTTPMutex.Unlock()
 	if fake.ServeHTTPStub != nil {
 		fake.ServeHTTPStub(arg1, arg2)
 	}

--- a/fixtures/fixturesfakes/fake_first_interface.go
+++ b/fixtures/fixturesfakes/fake_first_interface.go
@@ -18,10 +18,10 @@ type FakeFirstInterface struct {
 
 func (fake *FakeFirstInterface) DoThings() {
 	fake.doThingsMutex.Lock()
+	defer fake.doThingsMutex.Unlock()
 	fake.doThingsArgsForCall = append(fake.doThingsArgsForCall, struct {
 	}{})
 	fake.recordInvocation("DoThings", []interface{}{})
-	fake.doThingsMutex.Unlock()
 	if fake.DoThingsStub != nil {
 		fake.DoThingsStub()
 	}

--- a/fixtures/fixturesfakes/fake_has_imports.go
+++ b/fixtures/fixturesfakes/fake_has_imports.go
@@ -29,13 +29,13 @@ type FakeHasImports struct {
 
 func (fake *FakeHasImports) DoThings(arg1 io.Writer, arg2 *os.File) *http.Client {
 	fake.doThingsMutex.Lock()
+	defer fake.doThingsMutex.Unlock()
 	ret, specificReturn := fake.doThingsReturnsOnCall[len(fake.doThingsArgsForCall)]
 	fake.doThingsArgsForCall = append(fake.doThingsArgsForCall, struct {
 		arg1 io.Writer
 		arg2 *os.File
 	}{arg1, arg2})
 	fake.recordInvocation("DoThings", []interface{}{arg1, arg2})
-	fake.doThingsMutex.Unlock()
 	if fake.DoThingsStub != nil {
 		return fake.DoThingsStub(arg1, arg2)
 	}

--- a/fixtures/fixturesfakes/fake_has_other_types.go
+++ b/fixtures/fixturesfakes/fake_has_other_types.go
@@ -25,12 +25,12 @@ type FakeHasOtherTypes struct {
 
 func (fake *FakeHasOtherTypes) GetThing(arg1 fixtures.SomeString) fixtures.SomeFunc {
 	fake.getThingMutex.Lock()
+	defer fake.getThingMutex.Unlock()
 	ret, specificReturn := fake.getThingReturnsOnCall[len(fake.getThingArgsForCall)]
 	fake.getThingArgsForCall = append(fake.getThingArgsForCall, struct {
 		arg1 fixtures.SomeString
 	}{arg1})
 	fake.recordInvocation("GetThing", []interface{}{arg1})
-	fake.getThingMutex.Unlock()
 	if fake.GetThingStub != nil {
 		return fake.GetThingStub(arg1)
 	}

--- a/fixtures/fixturesfakes/fake_has_var_args.go
+++ b/fixtures/fixturesfakes/fake_has_var_args.go
@@ -39,6 +39,7 @@ type FakeHasVarArgs struct {
 
 func (fake *FakeHasVarArgs) DoMoreThings(arg1 int, arg2 int, arg3 ...string) int {
 	fake.doMoreThingsMutex.Lock()
+	defer fake.doMoreThingsMutex.Unlock()
 	ret, specificReturn := fake.doMoreThingsReturnsOnCall[len(fake.doMoreThingsArgsForCall)]
 	fake.doMoreThingsArgsForCall = append(fake.doMoreThingsArgsForCall, struct {
 		arg1 int
@@ -46,7 +47,6 @@ func (fake *FakeHasVarArgs) DoMoreThings(arg1 int, arg2 int, arg3 ...string) int
 		arg3 []string
 	}{arg1, arg2, arg3})
 	fake.recordInvocation("DoMoreThings", []interface{}{arg1, arg2, arg3})
-	fake.doMoreThingsMutex.Unlock()
 	if fake.DoMoreThingsStub != nil {
 		return fake.DoMoreThingsStub(arg1, arg2, arg3...)
 	}
@@ -101,13 +101,13 @@ func (fake *FakeHasVarArgs) DoMoreThingsReturnsOnCall(i int, result1 int) {
 
 func (fake *FakeHasVarArgs) DoThings(arg1 int, arg2 ...string) int {
 	fake.doThingsMutex.Lock()
+	defer fake.doThingsMutex.Unlock()
 	ret, specificReturn := fake.doThingsReturnsOnCall[len(fake.doThingsArgsForCall)]
 	fake.doThingsArgsForCall = append(fake.doThingsArgsForCall, struct {
 		arg1 int
 		arg2 []string
 	}{arg1, arg2})
 	fake.recordInvocation("DoThings", []interface{}{arg1, arg2})
-	fake.doThingsMutex.Unlock()
 	if fake.DoThingsStub != nil {
 		return fake.DoThingsStub(arg1, arg2...)
 	}

--- a/fixtures/fixturesfakes/fake_has_var_args_with_local_types.go
+++ b/fixtures/fixturesfakes/fake_has_var_args_with_local_types.go
@@ -19,11 +19,11 @@ type FakeHasVarArgsWithLocalTypes struct {
 
 func (fake *FakeHasVarArgsWithLocalTypes) DoThings(arg1 ...fixtures.LocalType) {
 	fake.doThingsMutex.Lock()
+	defer fake.doThingsMutex.Unlock()
 	fake.doThingsArgsForCall = append(fake.doThingsArgsForCall, struct {
 		arg1 []fixtures.LocalType
 	}{arg1})
 	fake.recordInvocation("DoThings", []interface{}{arg1})
-	fake.doThingsMutex.Unlock()
 	if fake.DoThingsStub != nil {
 		fake.DoThingsStub(arg1...)
 	}

--- a/fixtures/fixturesfakes/fake_imports_go_hyphen_package.go
+++ b/fixtures/fixturesfakes/fake_imports_go_hyphen_package.go
@@ -20,11 +20,11 @@ type FakeImportsGoHyphenPackage struct {
 
 func (fake *FakeImportsGoHyphenPackage) UseHyphenType(arg1 hyphenpackage.HyphenType) {
 	fake.useHyphenTypeMutex.Lock()
+	defer fake.useHyphenTypeMutex.Unlock()
 	fake.useHyphenTypeArgsForCall = append(fake.useHyphenTypeArgsForCall, struct {
 		arg1 hyphenpackage.HyphenType
 	}{arg1})
 	fake.recordInvocation("UseHyphenType", []interface{}{arg1})
-	fake.useHyphenTypeMutex.Unlock()
 	if fake.UseHyphenTypeStub != nil {
 		fake.UseHyphenTypeStub(arg1)
 	}

--- a/fixtures/fixturesfakes/fake_inline_struct_params.go
+++ b/fixtures/fixturesfakes/fake_inline_struct_params.go
@@ -47,6 +47,7 @@ func (fake *FakeInlineStructParams) DoSomething(arg1 context.Context, arg2 struc
 	HTTPRequest       http.Request
 }) error {
 	fake.doSomethingMutex.Lock()
+	defer fake.doSomethingMutex.Unlock()
 	ret, specificReturn := fake.doSomethingReturnsOnCall[len(fake.doSomethingArgsForCall)]
 	fake.doSomethingArgsForCall = append(fake.doSomethingArgsForCall, struct {
 		arg1 context.Context
@@ -59,7 +60,6 @@ func (fake *FakeInlineStructParams) DoSomething(arg1 context.Context, arg2 struc
 		}
 	}{arg1, arg2})
 	fake.recordInvocation("DoSomething", []interface{}{arg1, arg2})
-	fake.doSomethingMutex.Unlock()
 	if fake.DoSomethingStub != nil {
 		return fake.DoSomethingStub(arg1, arg2)
 	}

--- a/fixtures/fixturesfakes/fake_reuses_arg_types.go
+++ b/fixtures/fixturesfakes/fake_reuses_arg_types.go
@@ -20,12 +20,12 @@ type FakeReusesArgTypes struct {
 
 func (fake *FakeReusesArgTypes) DoThings(arg1 string, arg2 string) {
 	fake.doThingsMutex.Lock()
+	defer fake.doThingsMutex.Unlock()
 	fake.doThingsArgsForCall = append(fake.doThingsArgsForCall, struct {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
 	fake.recordInvocation("DoThings", []interface{}{arg1, arg2})
-	fake.doThingsMutex.Unlock()
 	if fake.DoThingsStub != nil {
 		fake.DoThingsStub(arg1, arg2)
 	}

--- a/fixtures/fixturesfakes/fake_second_interface.go
+++ b/fixtures/fixturesfakes/fake_second_interface.go
@@ -24,11 +24,11 @@ type FakeSecondInterface struct {
 
 func (fake *FakeSecondInterface) EmbeddedMethod() string {
 	fake.embeddedMethodMutex.Lock()
+	defer fake.embeddedMethodMutex.Unlock()
 	ret, specificReturn := fake.embeddedMethodReturnsOnCall[len(fake.embeddedMethodArgsForCall)]
 	fake.embeddedMethodArgsForCall = append(fake.embeddedMethodArgsForCall, struct {
 	}{})
 	fake.recordInvocation("EmbeddedMethod", []interface{}{})
-	fake.embeddedMethodMutex.Unlock()
 	if fake.EmbeddedMethodStub != nil {
 		return fake.EmbeddedMethodStub()
 	}

--- a/fixtures/fixturesfakes/fake_something.go
+++ b/fixtures/fixturesfakes/fake_something.go
@@ -47,11 +47,11 @@ func (fake *FakeSomething) DoASlice(arg1 []byte) {
 		copy(arg1Copy, arg1)
 	}
 	fake.doASliceMutex.Lock()
+	defer fake.doASliceMutex.Unlock()
 	fake.doASliceArgsForCall = append(fake.doASliceArgsForCall, struct {
 		arg1 []byte
 	}{arg1Copy})
 	fake.recordInvocation("DoASlice", []interface{}{arg1Copy})
-	fake.doASliceMutex.Unlock()
 	if fake.DoASliceStub != nil {
 		fake.DoASliceStub(arg1)
 	}
@@ -78,11 +78,11 @@ func (fake *FakeSomething) DoASliceArgsForCall(i int) []byte {
 
 func (fake *FakeSomething) DoAnArray(arg1 [4]byte) {
 	fake.doAnArrayMutex.Lock()
+	defer fake.doAnArrayMutex.Unlock()
 	fake.doAnArrayArgsForCall = append(fake.doAnArrayArgsForCall, struct {
 		arg1 [4]byte
 	}{arg1})
 	fake.recordInvocation("DoAnArray", []interface{}{arg1})
-	fake.doAnArrayMutex.Unlock()
 	if fake.DoAnArrayStub != nil {
 		fake.DoAnArrayStub(arg1)
 	}
@@ -109,10 +109,10 @@ func (fake *FakeSomething) DoAnArrayArgsForCall(i int) [4]byte {
 
 func (fake *FakeSomething) DoNothing() {
 	fake.doNothingMutex.Lock()
+	defer fake.doNothingMutex.Unlock()
 	fake.doNothingArgsForCall = append(fake.doNothingArgsForCall, struct {
 	}{})
 	fake.recordInvocation("DoNothing", []interface{}{})
-	fake.doNothingMutex.Unlock()
 	if fake.DoNothingStub != nil {
 		fake.DoNothingStub()
 	}
@@ -132,13 +132,13 @@ func (fake *FakeSomething) DoNothingCalls(stub func()) {
 
 func (fake *FakeSomething) DoThings(arg1 string, arg2 uint64) (int, error) {
 	fake.doThingsMutex.Lock()
+	defer fake.doThingsMutex.Unlock()
 	ret, specificReturn := fake.doThingsReturnsOnCall[len(fake.doThingsArgsForCall)]
 	fake.doThingsArgsForCall = append(fake.doThingsArgsForCall, struct {
 		arg1 string
 		arg2 uint64
 	}{arg1, arg2})
 	fake.recordInvocation("DoThings", []interface{}{arg1, arg2})
-	fake.doThingsMutex.Unlock()
 	if fake.DoThingsStub != nil {
 		return fake.DoThingsStub(arg1, arg2)
 	}

--- a/fixtures/fixturesfakes/fake_something_else.go
+++ b/fixtures/fixturesfakes/fake_something_else.go
@@ -26,11 +26,11 @@ type FakeSomethingElse struct {
 
 func (fake *FakeSomethingElse) ReturnStuff() (int, int) {
 	fake.returnStuffMutex.Lock()
+	defer fake.returnStuffMutex.Unlock()
 	ret, specificReturn := fake.returnStuffReturnsOnCall[len(fake.returnStuffArgsForCall)]
 	fake.returnStuffArgsForCall = append(fake.returnStuffArgsForCall, struct {
 	}{})
 	fake.recordInvocation("ReturnStuff", []interface{}{})
-	fake.returnStuffMutex.Unlock()
 	if fake.ReturnStuffStub != nil {
 		return fake.ReturnStuffStub()
 	}

--- a/fixtures/fixturesfakes/fake_something_factory.go
+++ b/fixtures/fixturesfakes/fake_something_factory.go
@@ -26,13 +26,13 @@ type FakeSomethingFactory struct {
 
 func (fake *FakeSomethingFactory) Spy(arg1 string, arg2 map[string]interface{}) string {
 	fake.mutex.Lock()
+	defer fake.mutex.Unlock()
 	ret, specificReturn := fake.returnsOnCall[len(fake.argsForCall)]
 	fake.argsForCall = append(fake.argsForCall, struct {
 		arg1 string
 		arg2 map[string]interface{}
 	}{arg1, arg2})
 	fake.recordInvocation("SomethingFactory", []interface{}{arg1, arg2})
-	fake.mutex.Unlock()
 	if fake.Stub != nil {
 		return fake.Stub(arg1, arg2)
 	}

--- a/fixtures/fixturesfakes/fake_something_with_foreign_interface.go
+++ b/fixtures/fixturesfakes/fake_something_with_foreign_interface.go
@@ -25,12 +25,12 @@ type FakeSomethingWithForeignInterface struct {
 
 func (fake *FakeSomethingWithForeignInterface) Stuff(arg1 int) string {
 	fake.stuffMutex.Lock()
+	defer fake.stuffMutex.Unlock()
 	ret, specificReturn := fake.stuffReturnsOnCall[len(fake.stuffArgsForCall)]
 	fake.stuffArgsForCall = append(fake.stuffArgsForCall, struct {
 		arg1 int
 	}{arg1})
 	fake.recordInvocation("Stuff", []interface{}{arg1})
-	fake.stuffMutex.Unlock()
 	if fake.StuffStub != nil {
 		return fake.StuffStub(arg1)
 	}

--- a/fixtures/fixturesfakes/fake_unexported_func.go
+++ b/fixtures/fixturesfakes/fake_unexported_func.go
@@ -24,13 +24,13 @@ type FakeUnexportedFunc struct {
 
 func (fake *FakeUnexportedFunc) Spy(arg1 string, arg2 map[string]interface{}) string {
 	fake.mutex.Lock()
+	defer fake.mutex.Unlock()
 	ret, specificReturn := fake.returnsOnCall[len(fake.argsForCall)]
 	fake.argsForCall = append(fake.argsForCall, struct {
 		arg1 string
 		arg2 map[string]interface{}
 	}{arg1, arg2})
 	fake.recordInvocation("unexportedFunc", []interface{}{arg1, arg2})
-	fake.mutex.Unlock()
 	if fake.Stub != nil {
 		return fake.Stub(arg1, arg2)
 	}

--- a/fixtures/fixturesfakes/fake_unexported_interface.go
+++ b/fixtures/fixturesfakes/fake_unexported_interface.go
@@ -24,13 +24,13 @@ type FakeUnexportedInterface struct {
 
 func (fake *FakeUnexportedInterface) Method(arg1 string, arg2 map[string]interface{}) string {
 	fake.methodMutex.Lock()
+	defer fake.methodMutex.Unlock()
 	ret, specificReturn := fake.methodReturnsOnCall[len(fake.methodArgsForCall)]
 	fake.methodArgsForCall = append(fake.methodArgsForCall, struct {
 		arg1 string
 		arg2 map[string]interface{}
 	}{arg1, arg2})
 	fake.recordInvocation("Method", []interface{}{arg1, arg2})
-	fake.methodMutex.Unlock()
 	if fake.MethodStub != nil {
 		return fake.MethodStub(arg1, arg2)
 	}

--- a/fixtures/sql/sqlfakes/fake_db.go
+++ b/fixtures/sql/sqlfakes/fake_db.go
@@ -29,13 +29,13 @@ type FakeDB struct {
 
 func (fake *FakeDB) Exec(arg1 string, arg2 ...interface{}) (sqla.Result, error) {
 	fake.execMutex.Lock()
+	defer fake.execMutex.Unlock()
 	ret, specificReturn := fake.execReturnsOnCall[len(fake.execArgsForCall)]
 	fake.execArgsForCall = append(fake.execArgsForCall, struct {
 		arg1 string
 		arg2 []interface{}
 	}{arg1, arg2})
 	fake.recordInvocation("Exec", []interface{}{arg1, arg2})
-	fake.execMutex.Unlock()
 	if fake.ExecStub != nil {
 		return fake.ExecStub(arg1, arg2...)
 	}

--- a/fixtures/sync/syncfakes/fake_sync_something.go
+++ b/fixtures/sync/syncfakes/fake_sync_something.go
@@ -47,11 +47,11 @@ func (fake *FakeSyncSomething) DoASlice(arg1 []byte) {
 		copy(arg1Copy, arg1)
 	}
 	fake.doASliceMutex.Lock()
+	defer fake.doASliceMutex.Unlock()
 	fake.doASliceArgsForCall = append(fake.doASliceArgsForCall, struct {
 		arg1 []byte
 	}{arg1Copy})
 	fake.recordInvocation("DoASlice", []interface{}{arg1Copy})
-	fake.doASliceMutex.Unlock()
 	if fake.DoASliceStub != nil {
 		fake.DoASliceStub(arg1)
 	}
@@ -78,11 +78,11 @@ func (fake *FakeSyncSomething) DoASliceArgsForCall(i int) []byte {
 
 func (fake *FakeSyncSomething) DoAnArray(arg1 [4]byte) {
 	fake.doAnArrayMutex.Lock()
+	defer fake.doAnArrayMutex.Unlock()
 	fake.doAnArrayArgsForCall = append(fake.doAnArrayArgsForCall, struct {
 		arg1 [4]byte
 	}{arg1})
 	fake.recordInvocation("DoAnArray", []interface{}{arg1})
-	fake.doAnArrayMutex.Unlock()
 	if fake.DoAnArrayStub != nil {
 		fake.DoAnArrayStub(arg1)
 	}
@@ -109,10 +109,10 @@ func (fake *FakeSyncSomething) DoAnArrayArgsForCall(i int) [4]byte {
 
 func (fake *FakeSyncSomething) DoNothing() {
 	fake.doNothingMutex.Lock()
+	defer fake.doNothingMutex.Unlock()
 	fake.doNothingArgsForCall = append(fake.doNothingArgsForCall, struct {
 	}{})
 	fake.recordInvocation("DoNothing", []interface{}{})
-	fake.doNothingMutex.Unlock()
 	if fake.DoNothingStub != nil {
 		fake.DoNothingStub()
 	}
@@ -132,13 +132,13 @@ func (fake *FakeSyncSomething) DoNothingCalls(stub func()) {
 
 func (fake *FakeSyncSomething) DoThings(arg1 string, arg2 uint64) (int, error) {
 	fake.doThingsMutex.Lock()
+	defer fake.doThingsMutex.Unlock()
 	ret, specificReturn := fake.doThingsReturnsOnCall[len(fake.doThingsArgsForCall)]
 	fake.doThingsArgsForCall = append(fake.doThingsArgsForCall, struct {
 		arg1 string
 		arg2 uint64
 	}{arg1, arg2})
 	fake.recordInvocation("DoThings", []interface{}{arg1, arg2})
-	fake.doThingsMutex.Unlock()
 	if fake.DoThingsStub != nil {
 		return fake.DoThingsStub(arg1, arg2)
 	}

--- a/generator/function_template.go
+++ b/generator/function_template.go
@@ -54,6 +54,7 @@ func (fake *{{.Name}}) Spy({{.Function.Params.AsNamedArgsWithTypes}}) {{.Functio
 	}
 	{{- end}}
 	fake.mutex.Lock()
+	defer fake.mutex.Unlock()
 	{{if .Function.Returns.HasLength}}ret, specificReturn := fake.returnsOnCall[len(fake.argsForCall)]
 	{{end}}fake.argsForCall = append(fake.argsForCall, struct{
 		{{- range .Function.Params}}
@@ -61,7 +62,6 @@ func (fake *{{.Name}}) Spy({{.Function.Params.AsNamedArgsWithTypes}}) {{.Functio
 		{{- end}}
 	}{ {{- .Function.Params.AsNamedArgs -}} })
 	fake.recordInvocation("{{.TargetName}}", []interface{}{ {{- if .Function.Params.HasLength}}{{.Function.Params.AsNamedArgs}}{{end -}} })
-	fake.mutex.Unlock()
 	if fake.Stub != nil {
 		{{if .Function.Returns.HasLength}}return fake.Stub({{.Function.Params.AsNamedArgsForInvocation}}){{else}}fake.Stub({{.Function.Params.AsNamedArgsForInvocation}}){{end}}
 	}

--- a/generator/interface_template.go
+++ b/generator/interface_template.go
@@ -58,6 +58,7 @@ func (fake *{{$.Name}}) {{.Name}}({{.Params.AsNamedArgsWithTypes}}) {{.Returns.A
 	}
 	{{- end}}
 	fake.{{UnExport .Name}}Mutex.Lock()
+	defer fake.{{UnExport .Name}}Mutex.Unlock()
 	{{- if .Returns.HasLength}}
 	ret, specificReturn := fake.{{UnExport .Name}}ReturnsOnCall[len(fake.{{UnExport .Name}}ArgsForCall)]
 	{{- end}}
@@ -67,7 +68,6 @@ func (fake *{{$.Name}}) {{.Name}}({{.Params.AsNamedArgsWithTypes}}) {{.Returns.A
 		{{- end}}
 	}{ {{- .Params.AsNamedArgs -}} })
 	fake.recordInvocation("{{.Name}}", []interface{}{ {{- if .Params.HasLength}}{{.Params.AsNamedArgs}}{{end -}} })
-	fake.{{UnExport .Name}}Mutex.Unlock()
 	if fake.{{.Name}}Stub != nil {
 		{{- if .Returns.HasLength}}
 		return fake.{{.Name}}Stub({{.Params.AsNamedArgsForInvocation}}){{else}}fake.{{.Name}}Stub({{.Params.AsNamedArgsForInvocation}})


### PR DESCRIPTION
Prevent a data race from occurring by deferring `mutex.Unlock`.

- Fixes #141 
- Fixes #149