### PR TITLE
Add -q flag to suppress status output

### DIFF
--- a/arguments/parser.go
+++ b/arguments/parser.go
@@ -45,6 +45,11 @@ func New(args []string, workingDir string, evaler Evaler, stater Stater) (*Parse
 		"",
 		"A path to a file that should be used as a header for the generated fake",
 	)
+	quietFlag := fs.Bool(
+		"q",
+		false,
+		"Suppress status statements",
+	)
 	helpFlag := fs.Bool(
 		"help",
 		false,
@@ -68,6 +73,7 @@ func New(args []string, workingDir string, evaler Evaler, stater Stater) (*Parse
 		GenerateInterfaceAndShimFromPackageDirectory: packageMode,
 		GenerateMode: *generateFlag,
 		HeaderFile:   *headerFlag,
+		Quiet:        *quietFlag,
 	}
 	if *generateFlag {
 		return result, nil
@@ -199,6 +205,7 @@ type ParsedArguments struct {
 
 	PrintToStdOut bool
 	GenerateMode  bool
+	Quiet         bool
 
 	HeaderFile string
 }

--- a/arguments/parser_windows_test.go
+++ b/arguments/parser_windows_test.go
@@ -24,12 +24,12 @@ func TestParsingArguments(t *testing.T) {
 
 func testParsingArguments(t *testing.T, when spec.G, it spec.S) {
 	var (
-		err error
+		err        error
 		parsedArgs *arguments.ParsedArguments
-		args []string
+		args       []string
 		workingDir string
-		evaler arguments.Evaler
-		stater arguments.Stater
+		evaler     arguments.Evaler
+		stater     arguments.Stater
 	)
 
 	justBefore := func() {

--- a/main.go
+++ b/main.go
@@ -113,8 +113,10 @@ func disableCache() bool {
 }
 
 func generate(workingDir string, args *arguments.ParsedArguments, cache generator.Cacher, headerReader generator.FileReader) error {
-	if err := reportStarting(workingDir, args.OutputPath, args.FakeImplName); err != nil {
-		return err
+	if !args.Quiet {
+		if err := reportStarting(workingDir, args.OutputPath, args.FakeImplName); err != nil {
+			return err
+		}
 	}
 
 	b, err := doGenerate(workingDir, args, cache, headerReader)
@@ -125,7 +127,11 @@ func generate(workingDir string, args *arguments.ParsedArguments, cache generato
 	if err := printCode(b, args.OutputPath, args.PrintToStdOut); err != nil {
 		return err
 	}
-	fmt.Fprint(os.Stderr, "Done\n")
+
+	if !args.Quiet {
+		fmt.Fprint(os.Stderr, "Done\n")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Hi there!

First of all, thanks for all your efforts in building this great tool!

I'm submitting a PR to add a `-q` command line flag to hide the status logs it emits when generating fakes. For example,

```
Writing `FakeFoo` to `path/to/fake_foo.go`... Done
```

This would reduce the chatter in our build logs and allow us to more easily identify problematic lines.
